### PR TITLE
Bring back ability to add actions

### DIFF
--- a/frontend/src/components/QuestionsList.tsx
+++ b/frontend/src/components/QuestionsList.tsx
@@ -16,7 +16,7 @@ type Props = {
     organizationFilter?: Organization[]
 }
 
-const QuestionsList = ({ questions, viewProgression, disable, onQuestionSummarySelected, severityFilter, organizationFilter }: Props) => {
+const QuestionsList = ({ questions, viewProgression, disable, displayActions, onQuestionSummarySelected, severityFilter, organizationFilter }: Props) => {
     const { azureUniqueId: currentUserAzureUniqueId } = useParticipant()
 
     const answerHasSelectedSeverity = (question: Question, severityFilter: Severity[]) => {
@@ -53,6 +53,7 @@ const QuestionsList = ({ questions, viewProgression, disable, onQuestionSummaryS
                 return (
                     <QuestionItem
                         key={index}
+                        displayActions={displayActions}
                         question={question}
                         viewProgression={viewProgression}
                         disable={disable}


### PR DESCRIPTION
Due to insufficient testing it was missed that add actions button no
longer displays on Workshop and Follow-up tabs due to changes made in
15acdfcf6ae69a4d51e2c814e5bd59c761c700ea

No UI tests unfortunately are added yet, which creates high uncertainty with regards to whether current change breaks something else or not, so we need to find feasible solution soon.
Frameworks are good, but we need to figure out what can be  done with authentication (bypass, mock, use custom users?) and how to do that.

closes #455 