### PR TITLE
Link previous evaluation

### DIFF
--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -48,11 +48,15 @@ namespace api.GQL
             _logger = logger;
         }
 
-        public Evaluation CreateEvaluation(string name, string projectId)
+        public Evaluation CreateEvaluation(string name,
+                                           string projectId,
+                                           string previousEvaluationId)
         {
             string azureUniqueId = _authService.GetOID();
             Project project = _projectService.GetProject(projectId);
-            Evaluation evaluation = _evaluationService.Create(name, project);
+            Evaluation evaluation = _evaluationService.Create(
+                name, project, previousEvaluationId
+            );
             _participantService.Create(azureUniqueId, evaluation, Organization.All, Role.Facilitator);
 
             _questionService.CreateBulk(_questionTemplateService.ActiveQuestions(), evaluation);

--- a/backend/api/Migrations/20210719094100_PreviousEvaluationId.Designer.cs
+++ b/backend/api/Migrations/20210719094100_PreviousEvaluationId.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Context;
 
 namespace api.Migrations
 {
     [DbContext(typeof(BmtDbContext))]
-    partial class BmtDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210719094100_PreviousEvaluationId")]
+    partial class PreviousEvaluationId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/api/Migrations/20210719094100_PreviousEvaluationId.cs
+++ b/backend/api/Migrations/20210719094100_PreviousEvaluationId.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace api.Migrations
+{
+    public partial class PreviousEvaluationId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PreviousEvaluationId",
+                table: "Evaluations",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PreviousEvaluationId",
+                table: "Evaluations");
+        }
+    }
+}

--- a/backend/api/Models/Models.cs
+++ b/backend/api/Models/Models.cs
@@ -41,6 +41,8 @@ namespace api.Models
         public virtual Project Project { get; set; }
 
         public virtual string Summary { get; set; }
+
+        public virtual string PreviousEvaluationId { get; set; }
     }
 
     public class Participant

--- a/backend/api/Services/EvaluationService.cs
+++ b/backend/api/Services/EvaluationService.cs
@@ -19,7 +19,9 @@ namespace api.Services
             _context = context;
         }
 
-        public Evaluation Create(string name, Project project)
+        public Evaluation Create(string name,
+                                 Project project,
+                                 string previousEvaluationId)
         {
             DateTimeOffset createDate = DateTimeOffset.UtcNow;
 
@@ -30,7 +32,8 @@ namespace api.Services
                 Progression = Progression.Nomination,
                 Project = project,
                 Status = Status.Active,
-                Summary = ""
+                Summary = "",
+                PreviousEvaluationId = previousEvaluationId
             };
 
             _context.Evaluations.Add(newEvaluation);

--- a/backend/tests/GQL/Mutation.cs
+++ b/backend/tests/GQL/Mutation.cs
@@ -53,7 +53,7 @@ namespace tests
         {
             string projectId = _context.Projects.First().Id;
             int evaluationsBefore = _context.Evaluations.Count();
-            _mutation.CreateEvaluation("CreateEvaluation", projectId);
+            _mutation.CreateEvaluation("CreateEvaluation", projectId, "");
             int evaluationsAfter = _context.Evaluations.Count();
 
             Assert.Equal(evaluationsBefore + 1, evaluationsAfter);
@@ -63,7 +63,7 @@ namespace tests
         public void ProgressEvaluationToFollowup()
         {
             Project project = _projectService.Create("ProgressEvaluationToFollowup");
-            Evaluation evaluation = _evaluationService.Create("ProgressEvaluationToFollowup", project);
+            Evaluation evaluation = _evaluationService.Create("ProgressEvaluationToFollowup", project, "");
             Participant participant = _participantService.Create("ProgressEvaluationToFollowup", evaluation, Organization.All, Role.Facilitator);
 
             List<Question> questions = _questionService.CreateBulk(_questionTemplateService.GetAll().ToList(), evaluation);

--- a/backend/tests/Services/AnswerService.cs
+++ b/backend/tests/Services/AnswerService.cs
@@ -71,7 +71,7 @@ namespace tests
             ProjectService projectService = new ProjectService(_context);
             Project project = projectService.Create("AnswerService_GetFromQuestionExists");
             EvaluationService evaluationService = new EvaluationService(_context);
-            Evaluation evaluation = evaluationService.Create("AnswerService_GetFromQuestionExists", project);
+            Evaluation evaluation = evaluationService.Create("AnswerService_GetFromQuestionExists", project, "");
 
             ParticipantService participantService = new ParticipantService(_context);
             Participant participant = participantService.GetAll().ToList()[0];
@@ -143,7 +143,7 @@ namespace tests
             ProjectService projectService = new ProjectService(_context);
             Project project = projectService.Create("AnswerService_GetFromQuestionExists");
             EvaluationService evaluationService = new EvaluationService(_context);
-            Evaluation evaluation = evaluationService.Create("AnswerService_GetFromQuestionExists", project);
+            Evaluation evaluation = evaluationService.Create("AnswerService_GetFromQuestionExists", project, "");
 
             Participant participant = participantService.Create("CreateFollowUpAnswers_id", evaluation, Organization.All, Role.Facilitator);
             QuestionTemplateService qts = new QuestionTemplateService(_context);

--- a/backend/tests/Services/EvaluationService.cs
+++ b/backend/tests/Services/EvaluationService.cs
@@ -32,7 +32,7 @@ namespace tests
             EvaluationService evaluationService = new EvaluationService(_context);
 
             int nEvaluationsBefore = evaluationService.GetAll().Count();
-            evaluationService.Create("some_name", project);
+            evaluationService.Create("some_name", project, "");
             int nEvaluationsAfter = evaluationService.GetAll().Count();
 
             Assert.Equal(nEvaluationsBefore + 1, nEvaluationsAfter);
@@ -44,7 +44,7 @@ namespace tests
             Project project = GetProject();
 
             EvaluationService evaluationService = new EvaluationService(_context);
-            Evaluation evaluation = evaluationService.Create("some_name", project);
+            Evaluation evaluation = evaluationService.Create("some_name", project, "");
             Progression nextEvaluation = ServiceUtil.NextProgression(evaluation.Progression);
 
             Progression progressionBefore = evaluation.Progression;
@@ -68,7 +68,7 @@ namespace tests
             Project project = GetProject();
 
             EvaluationService evaluationService = new EvaluationService(_context);
-            Evaluation evaluationCreate = evaluationService.Create("some_evaluation_name", project);
+            Evaluation evaluationCreate = evaluationService.Create("some__name", project, "");
 
             Evaluation evaluationGet = evaluationService.GetEvaluation(evaluationCreate.Id);
 
@@ -80,7 +80,7 @@ namespace tests
         {
             Project project           = GetProject();
             EvaluationService service = new EvaluationService(_context);
-            Evaluation evaluation     = service.Create("eval_name", project);
+            Evaluation evaluation     = service.Create("eval_name", project, "");
 
             string summary = "Summary";
 

--- a/backend/tests/Services/ParticipantService.cs
+++ b/backend/tests/Services/ParticipantService.cs
@@ -119,7 +119,7 @@ namespace tests
             ParticipantService participantService = new ParticipantService(_context);
             EvaluationService evaluationService = new EvaluationService(_context);
             Project project = projectService.Create("ProgressAllParticipants");
-            Evaluation evaluation = evaluationService.Create("ProgressAllParticipants", project);
+            Evaluation evaluation = evaluationService.Create("ProgressAllParticipants", project, "");
             Participant participant1 = participantService.Create("ProgressAllParticipants1", evaluation, Organization.All, Role.Facilitator);
             Participant participant2 = participantService.Create("ProgressAllParticipants2", evaluation, Organization.Commissioning, Role.OrganizationLead);
 
@@ -140,7 +140,7 @@ namespace tests
             ParticipantService participantService = new ParticipantService(_context);
             EvaluationService evaluationService = new EvaluationService(_context);
             Project project = projectService.Create("ProgressParticipant");
-            Evaluation evaluation = evaluationService.Create("ProgressParticipant", project);
+            Evaluation evaluation = evaluationService.Create("ProgressParticipant", project, "");
             Participant participant = participantService.Create("ProgressParticipant", evaluation, Organization.All, Role.Facilitator);
 
             Progression progressionBefore = participant.Progression;

--- a/backend/tests/Services/QuestionService.cs
+++ b/backend/tests/Services/QuestionService.cs
@@ -29,7 +29,7 @@ namespace tests
             ProjectService projectService = new ProjectService(_context);
             Project project = projectService.Create("QuestionService_Create");
             EvaluationService evaluationService = new EvaluationService(_context);
-            Evaluation evaluation = evaluationService.Create("QuestionService_Create", project);
+            Evaluation evaluation = evaluationService.Create("QuestionService_Create", project, "");
 
             QuestionService questionService = new QuestionService(_context);
 
@@ -49,7 +49,7 @@ namespace tests
             ProjectService projectService = new ProjectService(_context);
             Project project = projectService.Create("QuestionService_CreateBulk");
             EvaluationService evaluationService = new EvaluationService(_context);
-            Evaluation evaluation = evaluationService.Create("QuestionService_CreateBulk", project);
+            Evaluation evaluation = evaluationService.Create("QuestionService_CreateBulk", project, "");
 
             QuestionService questionService = new QuestionService(_context);
 
@@ -77,7 +77,7 @@ namespace tests
             ProjectService projectService = new ProjectService(_context);
             Project project = projectService.Create("QuestionService_GetExists");
             EvaluationService evaluationService = new EvaluationService(_context);
-            Evaluation evaluation = evaluationService.Create("QuestionService_GetExists", project);
+            Evaluation evaluation = evaluationService.Create("QuestionService_GetExists", project, "");
 
             QuestionService questionService = new QuestionService(_context);
             Question questionCreate = questionService.Create(questionTemplate, evaluation);

--- a/frontend/cypress/integration/create_evaluation_spec.ts
+++ b/frontend/cypress/integration/create_evaluation_spec.ts
@@ -1,0 +1,110 @@
+import { Role } from '../../src/api/models'
+import { EvaluationSeed } from '../support/evaluation_seed'
+import { evaluationName } from '../support/helpers'
+import NominationPage from '../support/nomination'
+import ProjectPage from '../support/project'
+import users, { User } from '../support/users'
+
+
+const evaluationUserIsFacilitator = () => {
+    let seed = new EvaluationSeed({
+        nParticipants: 3,
+        namePrefix: 'user is Facilitator'
+    })
+    let user  = seed.participants[2]
+    user.role = Role.Facilitator
+    return seed
+}
+
+const evaluationUserIsParticipant = () => {
+    return new EvaluationSeed({
+        nParticipants: 3,
+        namePrefix: 'user is Participant'
+    })
+}
+
+const evaluationUserIsNotInIt = () => {
+    return new EvaluationSeed({
+        nParticipants: 2,
+        namePrefix: 'user is not part of this Evaluation'
+    })
+}
+
+
+describe('Creating a new Evaluation', () => {
+    const user: User = users[2]
+    let userIsFacilitator: EvaluationSeed
+    let userIsParticipant: EvaluationSeed
+    let userIsNotInEvaluation: EvaluationSeed
+
+    before( () => {
+        cy.login()
+        cy.interceptExternal()
+        userIsFacilitator = evaluationUserIsFacilitator()
+        userIsParticipant = evaluationUserIsParticipant()
+        userIsNotInEvaluation = evaluationUserIsNotInIt()
+
+        userIsFacilitator.plant()
+        userIsParticipant.plant()
+        userIsNotInEvaluation.plant()
+    })
+
+    beforeEach( () => {
+        cy.login(user)
+        const port = Cypress.env('FRONTEND_PORT') || '3000'
+        cy.visit(`http://localhost:${port}/123`)
+        cy.wait(1000) //const wait is not good, but don't know how to make it stable
+    })
+
+    it('Without setting a previous evaluation', () => {
+        const name = evaluationName({prefix: 'CreatedWithoutPrevLink'})
+
+        const projectPage = new ProjectPage()
+        projectPage.createEvaluationButton().click()
+
+        const dialog = new ProjectPage.CreateEvaluationDialog()
+        dialog.createEvaluation(name)
+
+        const nominationPage = new NominationPage()
+        nominationPage.evaluationTitle().should('have.text', name)
+    })
+
+    it('Choosing a previous evaluation where user is Participant', () => {
+        const name = evaluationName({prefix: 'CreatedWithPrevLink'})
+
+        const projectPage = new ProjectPage()
+        projectPage.createEvaluationButton().click()
+
+        const dialog = new ProjectPage.CreateEvaluationDialog()
+        dialog.createEvaluation(name, userIsParticipant.name)
+
+        const nominationPage = new NominationPage()
+        nominationPage.evaluationTitle().should('have.text', name)
+    })
+
+    it('Choosing a previous evaluation where user is Facilitator', () => {
+        const name = evaluationName({prefix: 'CreatedWithPrevLink'})
+
+        const projectPage = new ProjectPage()
+        projectPage.createEvaluationButton().click()
+
+        const dialog = new ProjectPage.CreateEvaluationDialog()
+        dialog.createEvaluation(name, userIsFacilitator.name)
+
+        const nominationPage = new NominationPage()
+        nominationPage.evaluationTitle().should('have.text', name)
+    })
+
+    it('Choosing a previous evaluation that user is not part of', () => {
+        const name = evaluationName({prefix: 'CreatedWithPrevLink'})
+
+        const projectPage = new ProjectPage()
+        projectPage.createEvaluationButton().click()
+
+        const dialog = new ProjectPage.CreateEvaluationDialog()
+        dialog.createEvaluation(name, userIsNotInEvaluation.name)
+
+        const nominationPage = new NominationPage()
+        nominationPage.evaluationTitle().should('have.text', name)
+    })
+})

--- a/frontend/cypress/integration/sample_seed.ts
+++ b/frontend/cypress/integration/sample_seed.ts
@@ -3,7 +3,10 @@ import { Organization, Priority, Progression, Severity } from '../../src/api/mod
 import {Action, Answer, Note, Summary} from '../support/mocks'
 
 const exampleSeed = () => {
-    let seed = new EvaluationSeed(Progression.Workshop, 2)
+    let seed = new EvaluationSeed({
+        progression: Progression.Workshop,
+        nParticipants: 2
+    })
 
     let facilitator = seed.participants[0]
     facilitator.progression = Progression.FollowUp

--- a/frontend/cypress/support/evaluation_seed.ts
+++ b/frontend/cypress/support/evaluation_seed.ts
@@ -13,6 +13,11 @@ import {
     PROGRESS_PARTICIPANT
 } from './gql'
 
+interface IEvaluationSeed {
+    progression?: Progression
+    nParticipants?: number
+    fusionProjectId?: string
+}
 
 /** Setup an arbitrary Evaluation state - and feed it to the backend DB
  *
@@ -113,11 +118,11 @@ export class EvaluationSeed {
     questions: Question[] = []
 
 
-    constructor(
-        progression: Progression,
-        nParticipants: number,
-        fusionProjectId: string = '123')
-    {
+    constructor({
+        progression = Progression.Individual,
+        nParticipants = 1,
+        fusionProjectId = '123'}: IEvaluationSeed
+    ){
         if (progression === undefined) {
             progression = Progression.Individual
         }

--- a/frontend/cypress/support/evaluation_seed.ts
+++ b/frontend/cypress/support/evaluation_seed.ts
@@ -1,5 +1,6 @@
 import { Progression, Question, Role } from '../../src/api/models'
 import users from './users'
+import { evaluationName } from './helpers'
 import { Answer, Action, Participant, Note, Summary } from './mocks'
 import {
     GET_PROJECT,
@@ -17,6 +18,7 @@ interface IEvaluationSeed {
     progression?: Progression
     nParticipants?: number
     fusionProjectId?: string
+    namePrefix?: string
 }
 
 /** Setup an arbitrary Evaluation state - and feed it to the backend DB
@@ -121,8 +123,9 @@ export class EvaluationSeed {
     constructor({
         progression = Progression.Individual,
         nParticipants = 1,
-        fusionProjectId = '123'}: IEvaluationSeed
-    ){
+        fusionProjectId = '123',
+        namePrefix = 'Evaluation'}: IEvaluationSeed
+    ) {
         if (progression === undefined) {
             progression = Progression.Individual
         }
@@ -151,7 +154,7 @@ export class EvaluationSeed {
 
         this.progression = progression
         this.fusionProjectId = fusionProjectId
-        this.name = 'Evaluation-' + Date.now()
+        this.name = evaluationName({prefix: namePrefix})
     }
 
     addAnswer(answer: Answer) {

--- a/frontend/cypress/support/helpers.ts
+++ b/frontend/cypress/support/helpers.ts
@@ -5,5 +5,5 @@ interface IEvaluationName {
 }
 
 export const evaluationName = ({prefix='Evaluation'}: IEvaluationName) => {
-    return `${prefix}-(${Date.now()}) `
+    return `${prefix}-(${Math.floor(Math.random() * 1000000)})`
 }

--- a/frontend/cypress/support/helpers.ts
+++ b/frontend/cypress/support/helpers.ts
@@ -1,0 +1,9 @@
+
+
+interface IEvaluationName {
+    prefix: string
+}
+
+export const evaluationName = ({prefix='Evaluation'}: IEvaluationName) => {
+    return `${prefix}-(${Date.now()}) `
+}

--- a/frontend/cypress/support/project.ts
+++ b/frontend/cypress/support/project.ts
@@ -17,5 +17,19 @@ export default class ProjectPage {
              */
             return cy.get('[data-testid=create_evaluation_dialog_create_button_grid]').then($el => cy.wrap($el).find('button'))
         }
+
+        previousEvaluation = () => {
+            return cy.contains('Previous Evaluation').parent()
+        }
+
+        createEvaluation = (name: string, previousEvaluation?: string) => {
+            this.nameTextField().type(name)
+
+            if (previousEvaluation) {
+                this.previousEvaluation().click().type(`${previousEvaluation}{enter}`)
+            }
+
+            this.createButton().click()
+        }
     }
 }

--- a/frontend/src/api/fragments.ts
+++ b/frontend/src/api/fragments.ts
@@ -26,6 +26,7 @@ export const EVALUATION_FIELDS_FRAGMENT = gql`
         name
         progression
         summary
+        previousEvaluationId
         __typename
     }
 `

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -148,6 +148,7 @@ export type Evaluation = {
   questions: Array<Maybe<Question>>;
   project: Project;
   summary?: Maybe<Scalars['String']>;
+  previousEvaluationId?: Maybe<Scalars['String']>;
 };
 
 export type EvaluationFilterInput = {
@@ -162,6 +163,7 @@ export type EvaluationFilterInput = {
   questions?: Maybe<ListFilterInputTypeOfQuestionFilterInput>;
   project?: Maybe<ProjectFilterInput>;
   summary?: Maybe<StringOperationFilterInput>;
+  previousEvaluationId?: Maybe<StringOperationFilterInput>;
 };
 
 export type GraphQuery = {
@@ -280,6 +282,7 @@ export type Mutation = {
 export type MutationCreateEvaluationArgs = {
   name?: Maybe<Scalars['String']>;
   projectId?: Maybe<Scalars['String']>;
+  previousEvaluationId?: Maybe<Scalars['String']>;
 };
 
 

--- a/frontend/src/views/Project/Dashboard/CreateEvaluationButton.tsx
+++ b/frontend/src/views/Project/Dashboard/CreateEvaluationButton.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react'
 import { Redirect } from 'react-router-dom'
 
-import { Button, TextArea } from '@equinor/fusion-components'
+import { Button, SearchableDropdownOption, TextArea } from '@equinor/fusion-components'
 import CreateEvaluationDialog from './CreateEvaluationDialog'
-import { useCreateEvaluationMutation } from './ProjectDashboardGQL'
+import { useCreateEvaluationMutation, useGetAllEvaluationsQuery } from './ProjectDashboardGQL'
 import { useProject } from '../../../globals/contexts'
 
 interface CreateEvaluationButtonProps {
@@ -11,26 +11,39 @@ interface CreateEvaluationButtonProps {
 }
 
 const CreateEvaluationButton = ({ projectId }: CreateEvaluationButtonProps) => {
-    const [showDialog, setShowDialog] = useState<boolean>(false)
-    const { createEvaluation, loading, evaluation, error } = useCreateEvaluationMutation()
-
     const project = useProject()
+    const [showDialog, setShowDialog] = useState<boolean>(false)
 
-    const onCreateEvaluationDialogSureClick = (name: string) => {
+    const onCreateEvaluationDialogSureClick = (
+        name: string,
+        previousEvaluationId?: string
+    ) => {
         setShowDialog(false)
-        createEvaluation(name, projectId)
+        createEvaluation(name, projectId, previousEvaluationId)
     }
+
     const onCreateEvaluationDialogCancelClick = () => {
         setShowDialog(false)
     }
+
     const onCreateEvaluationButtonClick = () => {
         setShowDialog(true)
     }
 
-    if (error !== undefined) {
+    const {
+        createEvaluation,
+        loading: loadingMutation,
+        evaluation,
+        error: errorMutation
+    } = useCreateEvaluationMutation()
+
+    if (errorMutation !== undefined) {
         return (
             <div>
-                <TextArea value={JSON.stringify(error)} onChange={() => {}} />
+                <TextArea
+                    value={JSON.stringify(errorMutation)}
+                    onChange={() => {}}
+                />
             </div>
         )
     }
@@ -38,7 +51,10 @@ const CreateEvaluationButton = ({ projectId }: CreateEvaluationButtonProps) => {
     if (evaluation === undefined) {
         return (
             <>
-                <Button onClick={onCreateEvaluationButtonClick} disabled={loading}>
+                <Button
+                    onClick={onCreateEvaluationButtonClick}
+                    disabled={loadingMutation}
+                >
                     Create evaluation
                 </Button>
 

--- a/frontend/src/views/Project/Dashboard/ProjectDashboardGQL.ts
+++ b/frontend/src/views/Project/Dashboard/ProjectDashboardGQL.ts
@@ -35,8 +35,36 @@ export const useEvaluationsQuery = (projectId: string, azureUniqueId: string): E
     }
 }
 
+export const useGetAllEvaluationsQuery = (
+    projectId: string
+): EvaluationQueryProps => {
+    const GET_EVALUATIONS = gql`
+        query($projectId: String!) {
+            evaluations(where: { project: { id: { eq: $projectId } } }) {
+                id
+                name
+            }
+        }
+    `
+
+    const { loading, data, error } = useQuery<{ evaluations: Evaluation[] }>(
+        GET_EVALUATIONS,
+        { variables: { projectId } }
+    )
+
+    return {
+        loading,
+        evaluations: data?.evaluations,
+        error,
+    }
+}
+
 interface CreateEvaluationMutationProps {
-    createEvaluation: (name: string, projectId: string) => void
+    createEvaluation: (
+        name: string,
+        projectId: string,
+        previousEvaluationId?: string
+    ) => void
     loading: boolean
     evaluation: Evaluation | undefined
     error: ApolloError | undefined
@@ -44,8 +72,16 @@ interface CreateEvaluationMutationProps {
 
 export const useCreateEvaluationMutation = (): CreateEvaluationMutationProps => {
     const ADD_EVALUATION = gql`
-        mutation CreateEvaluation($name: String!, $projectId: String!) {
-            createEvaluation(name: $name, projectId: $projectId) {
+        mutation CreateEvaluation(
+            $name: String!
+            $projectId: String!
+            $previousEvaluationId: String
+        ) {
+            createEvaluation(
+                name: $name
+                projectId: $projectId
+                previousEvaluationId: $previousEvaluationId
+            ) {
                 ...EvaluationFields
             }
         }
@@ -68,8 +104,14 @@ export const useCreateEvaluationMutation = (): CreateEvaluationMutationProps => 
         },
     })
 
-    const createEvaluation = (name: string, projectId: string) => {
-        createEvaluationApolloFunc({ variables: { name, projectId } })
+    const createEvaluation = (
+        name: string,
+        projectId: string,
+        previousEvaluationId?: string
+    ) => {
+        createEvaluationApolloFunc({
+            variables: { name, projectId, previousEvaluationId },
+        })
     }
 
     return {


### PR DESCRIPTION
Give users the option to add a link to a previous evaluation when
creating a new evaluation. For now this link is not used anywhere else
in the frontend.

Run `dotnet ef database update` on dev database after merging

Closes #446 