### PR TITLE
Progress indicator in workshop tab now counts all answers

### DIFF
--- a/frontend/src/utils/QuestionAndAnswerUtils.test.ts
+++ b/frontend/src/utils/QuestionAndAnswerUtils.test.ts
@@ -28,84 +28,178 @@ describe('Test QuestionAndAnswerUtils', () => {
 
             expect(isFilledOut).toBe(true)
         })
-    it('Check if getFilledUserAnswersForProgression gets correct answers', () => {
-        const evaluation: Evaluation = {
-            createDate: new Date(),
-            id: '',
-            name: '',
-            participants: [],
-            progression: Progression.Preparation,
-            status: Status.Active,
-            project: {
-                createDate: new Date(),
-                evaluations: [],
-                fusionProjectId: '',
-                id: '',
-            },
-            questions: [],
-        }
+})
 
-        const question: Question = {
-            actions: [],
-            answers: [],
-            barrier: Barrier.Gm,
-            createDate: new Date(),
-            evaluation,
-            order: 1,
-            id: '',
-            organization: Organization.All,
-            questionTemplate: {
-                barrier: Barrier.Gm,
-                createDate: new Date(),
-                id: '',
-                order: 1,
-                organization: Organization.All,
-                questions: [],
-                status: Status.Active,
-                supportNotes: '',
-                text: '',
-            },
-            supportNotes: '',
-            text: '',
-        }
-
-        const participant: Participant = {
-            azureUniqueId: '1',
-            createDate: new Date(),
-            evaluation,
-            evaluationId: evaluation.id,
-            id: '',
-            organization: Organization.All,
-            progression: Progression.Preparation,
-            role: Role.OrganizationLead,
-        }
-
-        const answer1: Answer = {
-            createDate: new Date(),
-            id: '',
-            progression: Progression.Preparation,
-            question,
-            questionId: '',
-            severity: Severity.High,
-            text: 'answer1',
-            answeredBy: participant,
-        }
-
-        const answer2: Answer = {
-            createDate: new Date(),
-            id: '',
-            progression: Progression.Individual,
-            question,
-            questionId: '',
-            severity: Severity.High,
-            text: 'answer2',
-            answeredBy: participant,
-        }
-
+describe('Test getFilledUserAnswersForProgression', () => {
+    it('gets answers only from the stage the user is currently at', () => {
         question.answers = [answer1, answer2]
 
         const answers = getFilledUserAnswersForProgression([question], Progression.Preparation, participant.azureUniqueId)
 
         expect(answers.length).toBe(1)
     })
+
+    it('get only the users own answers, not answers from others, from the current stage', () => {
+        question.answers = [answer2, answer5]
+
+        const answers = getFilledUserAnswersForProgression([question], Progression.Individual, participant.azureUniqueId)
+
+        expect(answers.length).toBe(1)
+        expect(answers[0].answeredBy && answers[0].answeredBy.azureUniqueId).toBe(participant.azureUniqueId)
+    })
+
+    it('gets answers from all users on workshop step', () => {
+        question.answers = [answer3, answer4]
+
+        const answers = getFilledUserAnswersForProgression([question], Progression.Workshop, facilitator1.azureUniqueId)
+
+        expect(answers.length).toBe(2)
+    })
+
+    it('gets answers from all users on workshop step, also when participant and not facilitator is using the application', () => {
+        question.answers = [answer3, answer4]
+
+        const answers = getFilledUserAnswersForProgression([question], Progression.Workshop, participant.azureUniqueId)
+
+        expect(answers.length).toBe(2)
+    })
+
+    const evaluation: Evaluation = {
+        createDate: new Date(),
+        id: '',
+        name: '',
+        participants: [],
+        progression: Progression.Preparation,
+        status: Status.Active,
+        project: {
+            createDate: new Date(),
+            evaluations: [],
+            fusionProjectId: '',
+            id: '',
+        },
+        questions: [],
+    }
+
+    const question: Question = {
+        actions: [],
+        answers: [],
+        barrier: Barrier.Gm,
+        createDate: new Date(),
+        evaluation,
+        order: 1,
+        id: '',
+        organization: Organization.All,
+        questionTemplate: {
+            barrier: Barrier.Gm,
+            createDate: new Date(),
+            id: '',
+            order: 1,
+            organization: Organization.All,
+            questions: [],
+            status: Status.Active,
+            supportNotes: '',
+            text: '',
+        },
+        supportNotes: '',
+        text: '',
+    }
+
+    const participant: Participant = {
+        azureUniqueId: '1',
+        createDate: new Date(),
+        evaluation,
+        evaluationId: evaluation.id,
+        id: '',
+        organization: Organization.All,
+        progression: Progression.Preparation,
+        role: Role.OrganizationLead,
+    }
+
+    const participant2: Participant = {
+        azureUniqueId: '2',
+        createDate: new Date(),
+        evaluation,
+        evaluationId: evaluation.id,
+        id: '',
+        organization: Organization.All,
+        progression: Progression.Preparation,
+        role: Role.Participant,
+    }
+
+    const facilitator1: Participant = {
+        azureUniqueId: 'a',
+        createDate: new Date(),
+        evaluation,
+        evaluationId: evaluation.id,
+        id: '',
+        organization: Organization.All,
+        progression: Progression.Workshop,
+        role: Role.Facilitator,
+    }
+
+    const facilitator2: Participant = {
+        azureUniqueId: 'b',
+        createDate: new Date(),
+        evaluation,
+        evaluationId: evaluation.id,
+        id: '',
+        organization: Organization.All,
+        progression: Progression.Workshop,
+        role: Role.Facilitator,
+    }
+
+    const answer1: Answer = {
+        createDate: new Date(),
+        id: '',
+        progression: Progression.Preparation,
+        question,
+        questionId: '',
+        severity: Severity.High,
+        text: 'answer1',
+        answeredBy: participant,
+    }
+
+    const answer2: Answer = {
+        createDate: new Date(),
+        id: '',
+        progression: Progression.Individual,
+        question,
+        questionId: '',
+        severity: Severity.High,
+        text: 'answer2',
+        answeredBy: participant,
+    }
+
+    const answer3: Answer = {
+        createDate: new Date(),
+        id: '',
+        progression: Progression.Workshop,
+        question,
+        questionId: '',
+        severity: Severity.Low,
+        text: 'answer3',
+        answeredBy: facilitator1,
+    }
+
+    const answer4: Answer = {
+        createDate: new Date(),
+        id: '',
+        progression: Progression.Workshop,
+        question,
+        questionId: '',
+        severity: Severity.Limited,
+        text: 'answer4',
+        answeredBy: facilitator2,
+    }
+
+    const answer5: Answer = {
+        createDate: new Date(),
+        id: '',
+        progression: Progression.Individual,
+        question,
+        questionId: '',
+        severity: Severity.Low,
+        text: 'answer5',
+        answeredBy: participant2,
+    }
 })

--- a/frontend/src/utils/QuestionAndAnswerUtils.ts
+++ b/frontend/src/utils/QuestionAndAnswerUtils.ts
@@ -1,8 +1,5 @@
 import { Answer, Organization, Progression, Question, Severity } from '../api/models'
-import {
-    findCorrectAnswer,
-    useSharedFacilitatorAnswer
-} from '../components/helpers'
+import { findCorrectAnswer, useSharedFacilitatorAnswer } from '../components/helpers'
 
 export const checkIfAnswerFilled = (answer: Answer): boolean => {
     return answer.text !== ''
@@ -12,35 +9,25 @@ export const getFilledUserAnswersForProgression = (questions: Question[], progre
     const progressionAnswers = questions.reduce((acc: Answer[], cur: Question) => {
         return acc.concat(cur.answers.filter((a: Answer) => a.progression === progression))
     }, [] as Answer[])
-    const participantAnswers = progressionAnswers.filter(a => a.answeredBy?.azureUniqueId === azureUniqueId)
+    const participantAnswers =
+        progression === Progression.Workshop
+            ? progressionAnswers
+            : progressionAnswers.filter(a => a.answeredBy?.azureUniqueId === azureUniqueId)
     return participantAnswers.filter(a => checkIfAnswerFilled(a))
 }
 
-export const hasSeverity = (
-    question: Question,
-    severityFilter: Severity[],
-    AzureUniqueId: string,
-    viewProgression: Progression
-) => {
+export const hasSeverity = (question: Question, severityFilter: Severity[], AzureUniqueId: string, viewProgression: Progression) => {
     if (severityFilter.length === 0) {
         return true
     } else {
         const useSharedAnswer = useSharedFacilitatorAnswer(viewProgression)
-        const answer = findCorrectAnswer(
-            question,
-            viewProgression,
-            useSharedAnswer,
-            AzureUniqueId
-        )
+        const answer = findCorrectAnswer(question, viewProgression, useSharedAnswer, AzureUniqueId)
         const severity = (answer && answer.severity) || Severity.Na
         return severityFilter.includes(severity)
     }
 }
 
-export const hasOrganization = (
-    question: Question,
-    organizationFilter: Organization[]
-) => {
+export const hasOrganization = (question: Question, organizationFilter: Organization[]) => {
     if (organizationFilter.length === 0) {
         return true
     } else {
@@ -48,7 +35,7 @@ export const hasOrganization = (
     }
 }
 
-export const toggleFilter = <T,>(value: T, filter: T[]) => {
+export const toggleFilter = <T>(value: T, filter: T[]) => {
     if (filter.includes(value)) {
         return filter.filter(x => x !== value)
     } else {


### PR DESCRIPTION
**Context**: In all steps of BMT, there is a side panel next to the questions that count how many questions are answered. The Workshop tab works a bit different than the other tabs, because here only facilitators can write answers, and if there are more than one facilitator, there can be answers from either of these on either of the questions.

![image](https://user-images.githubusercontent.com/1130244/128172485-d4a52ef9-ee6c-47db-a872-648bf4ed78bf.png)

**Problem**: Even though multiple respondents can answer the questions, in the side panel, only the answers written by the logged in user will be counted. Therefore, we can easily get a situation where you can see that 10 out of 37 questions is answered, but in the side panel it only says that 1/37 questions are answered.

**Solution**: For the Workshop tab (`Progression.Workshop` in the code), we have to count all answers, not only the answers that match the logged in users azureId.

This PR looks like there is more new code than t here is because of prettier formatting, the only real change is the following: 

`const participantAnswers =
        progression === Progression.Workshop
            ? progressionAnswers
            : progressionAnswers.filter(a => a.answeredBy?.azureUniqueId === azureUniqueId)`

I.e. we now check if we are on the workshop step and only filter on azure ID if we aren't. Earlier code:

`const participantAnswers = progressionAnswers.filter(a => a.answeredBy?.azureUniqueId === azureUniqueId)`