### PR TITLE
Add role-based access to answers

### DIFF
--- a/frontend/src/components/AnswerSummarySidebar.tsx
+++ b/frontend/src/components/AnswerSummarySidebar.tsx
@@ -5,6 +5,8 @@ import { barrierToString } from '../utils/EnumToString'
 import SingleAnswerSummary from './SingleAnswerSummary'
 import { progressionLessThan } from '../utils/ProgressionStatus'
 import Sticky from './Sticky'
+import { useParticipant } from '../globals/contexts'
+import { participantCanReadAnswer } from '../utils/RoleBasedAccess'
 
 interface AnswerSummarySidebarProps {
     open: boolean
@@ -14,7 +16,10 @@ interface AnswerSummarySidebarProps {
 }
 
 const AnswerSummarySidebar = ({ open, onCloseClick, question, viewProgression }: AnswerSummarySidebarProps) => {
-    const answers = question.answers.filter(answer => progressionLessThan(answer.progression, viewProgression))
+    const participant = useParticipant()
+    const answers = question.answers.filter(answer =>
+        progressionLessThan(answer.progression, viewProgression) && participantCanReadAnswer(participant, answer)
+    )
 
     const individualAnswers = answers.filter(a => a.progression === Progression.Individual)
     const preparationAnswers = answers.filter(a => a.progression === Progression.Preparation)

--- a/frontend/src/utils/RoleBasedAccess.ts
+++ b/frontend/src/utils/RoleBasedAccess.ts
@@ -1,0 +1,22 @@
+import {Answer, Participant, Progression, Role} from "../api/models"
+
+
+/** Role-based access to an Answer
+ *
+ * Facilitator and OrganizationLead has access to everyone's answers.
+ * Participants and ReadOnly are not allowed to read other peoples _Individual_
+ * answers.
+ */
+export const participantCanReadAnswer = (participant: Participant, answer: Answer) => {
+    switch (participant.role) {
+        case Role.Facilitator: // Intentional fall-through
+        case Role.OrganizationLead:
+            return true
+        case Role.Participant: // Intentional fall-through
+        case Role.ReadOnly:
+            return (
+                answer.progression !== Progression.Individual ||
+                participant.id === answer.answeredBy?.id
+            )
+    }
+}


### PR DESCRIPTION
This commit prohibits participants with role Participant or ReadOnly to
view other participants individual answers in the AnswerSummarySidebar.

Closes #470 