### PR TITLE
Update Role privileges at Nomination step

### DIFF
--- a/frontend/src/utils/RoleBasedAccess.ts
+++ b/frontend/src/utils/RoleBasedAccess.ts
@@ -18,5 +18,7 @@ export const participantCanReadAnswer = (participant: Participant, answer: Answe
                 answer.progression !== Progression.Individual ||
                 participant.id === answer.answeredBy?.id
             )
+        default:
+            return false
     }
 }

--- a/frontend/src/utils/RoleBasedAccess.ts
+++ b/frontend/src/utils/RoleBasedAccess.ts
@@ -22,3 +22,18 @@ export const participantCanReadAnswer = (participant: Participant, answer: Answe
             return false
     }
 }
+
+
+/* Role-based rule for deleting another Participant from the Evaluation */
+export const participantCanDeleteParticipant = (participantRole: Role) => {
+    switch (participantRole) {
+        case Role.Facilitator: // Intentional fall-through
+        case Role.OrganizationLead:
+            return true
+        case Role.Participant: // Intentional fall-through
+        case Role.ReadOnly:
+            return false
+        default:
+            return false
+    }
+}

--- a/frontend/src/utils/RoleBasedAccess.ts
+++ b/frontend/src/utils/RoleBasedAccess.ts
@@ -37,3 +37,18 @@ export const participantCanDeleteParticipant = (participantRole: Role) => {
             return false
     }
 }
+
+
+/* Role-based rule for progressing an Evaluation */
+export const participantCanProgressEvaluation = (participantRole: Role) => {
+    switch (participantRole) {
+        case Role.Facilitator:
+            return true
+        case Role.OrganizationLead:
+        case Role.Participant: // Intentional fall-through
+        case Role.ReadOnly:
+            return false
+        default:
+            return false
+    }
+}

--- a/frontend/src/utils/RoleBasedAccess.ts
+++ b/frontend/src/utils/RoleBasedAccess.ts
@@ -24,6 +24,13 @@ export const participantCanReadAnswer = (participant: Participant, answer: Answe
 }
 
 
+/* Role-based rule for adding another Participant to the Evaluation */
+export const participantCanAddParticipant = (participantRole: Role) => {
+    /* Currently this share the same access as for deleting Participants */
+    return participantCanDeleteParticipant(participantRole)
+}
+
+
 /* Role-based rule for deleting another Participant from the Evaluation */
 export const participantCanDeleteParticipant = (participantRole: Role) => {
     switch (participantRole) {

--- a/frontend/src/views/Evaluation/Nomination/NominationTable.tsx
+++ b/frontend/src/views/Evaluation/Nomination/NominationTable.tsx
@@ -14,7 +14,6 @@ interface DataTableItem {
     organization: Organization
     role: Role
     participant: Participant
-    progressionStatus: ProgressionStatus
     rowIdentifier: string
     disableDelete: boolean
 }
@@ -106,17 +105,15 @@ const disableDelete = (evaluation: Evaluation, azureUniqueId: string) => {
 
 interface NominationTableProps {
     participants: Participant[]
-    currentProgressionStatus: ProgressionStatus
 }
 
-const NominationTable = ({ participants, currentProgressionStatus }: NominationTableProps) => {
+const NominationTable = ({ participants }: NominationTableProps) => {
     const disable = disableDelete(useEvaluation(), useAzureUniqueId())
 
     const data: DataTableItem[] = participants.map(participant => ({
         participant,
         organization: participant.organization,
         role: participant.role,
-        progressionStatus: currentProgressionStatus,
         rowIdentifier: participant.id,
         disableDelete: disable
     }))

--- a/frontend/src/views/Evaluation/Nomination/NominationTable.tsx
+++ b/frontend/src/views/Evaluation/Nomination/NominationTable.tsx
@@ -8,6 +8,7 @@ import { ProgressionStatus } from '../../../utils/ProgressionStatus'
 import { useDeleteParticipantMutation } from './NominationGQL'
 import { roleToString, organizationToString } from '../../../utils/EnumToString'
 import { useEvaluation } from '../../../globals/contexts'
+import { participantCanDeleteParticipant } from '../../../utils/RoleBasedAccess'
 
 interface DataTableItem {
     organization: Organization
@@ -81,10 +82,10 @@ const columns: DataTableColumn<DataTableItem>[] = [
     },
 ]
 
-/** Who can delete users, and when (Progression)
+/** Who (Role) can delete users, and when (Progression)
  *
  * Who:
- *  Participants that are a part of the evaluation
+ *  Facilitators and OrganizationLeads
  *
  * When:
  *  Evaluation is at Nomination stage
@@ -100,7 +101,7 @@ const disableDelete = (evaluation: Evaluation, azureUniqueId: string) => {
         return true
     }
 
-    return false
+    return !participantCanDeleteParticipant(loggedInUser.role)
 }
 
 interface NominationTableProps {

--- a/frontend/src/views/Evaluation/Nomination/NominationView.tsx
+++ b/frontend/src/views/Evaluation/Nomination/NominationView.tsx
@@ -7,7 +7,7 @@ import AddNomineeDialog from './AddNomineeDialog'
 import { Evaluation, Organization, Participant, Progression, Role } from '../../../api/models'
 import NominationTable from './NominationTable'
 import { useCreateParticipantMutation, useParticipantsQuery } from './NominationGQL'
-import { participantCanProgressEvaluation } from '../../../utils/RoleBasedAccess'
+import { participantCanProgressEvaluation, participantCanAddParticipant } from '../../../utils/RoleBasedAccess'
 import { useAzureUniqueId } from '../../../utils/Variables'
 
 interface NominationViewProps {
@@ -37,10 +37,29 @@ const disableProgression = (evaluation: Evaluation, azureUniqueId: string) => {
     return !participantCanProgressEvaluation(loggedInUser.role)
 }
 
+/** Who (Role) can add add users, and when (Progression)
+ *
+ * Who:
+ *  Facilitators and OrganizationLeads
+ *
+ * When:
+ *  Any Progression
+ */
+const disableAddParticipant = (evaluation: Evaluation, azureUniqueId: string) => {
+    const loggedInUser = evaluation.participants.find(p => p.azureUniqueId === azureUniqueId)
+
+    if (!loggedInUser) {
+        return true
+    }
+
+    return !participantCanAddParticipant(loggedInUser.role)
+}
+
 const NominationView = ({ evaluation, onNextStep }: NominationViewProps) => {
     const [panelOpen, setPanelOpen] = React.useState(false)
     const { createParticipant, error: errorMutation } = useCreateParticipantMutation()
     const { loading: loadingQuery, participants, error: errorQuery } = useParticipantsQuery(evaluation.id)
+    const azureUniqueId = useAzureUniqueId()
 
     const onNextStepClick = () => {
         onNextStep()
@@ -83,7 +102,7 @@ const NominationView = ({ evaluation, onNextStep }: NominationViewProps) => {
                     <h2 data-testid="evaluation_title">{evaluation.name}</h2>
                 </Box>
                 <Box>
-                    <Button onClick={onNextStepClick} disabled={disableProgression(evaluation, useAzureUniqueId())}>
+                    <Button onClick={onNextStepClick} disabled={disableProgression(evaluation, azureUniqueId)}>
                         Finish Nomination
                     </Button>
                 </Box>
@@ -93,6 +112,7 @@ const NominationView = ({ evaluation, onNextStep }: NominationViewProps) => {
                 onClick={() => {
                     setPanelOpen(true)
                 }}
+                disabled={disableAddParticipant(evaluation, azureUniqueId)}
             >
                 Add Person
             </Button>

--- a/frontend/src/views/Evaluation/Nomination/NominationView.tsx
+++ b/frontend/src/views/Evaluation/Nomination/NominationView.tsx
@@ -7,7 +7,6 @@ import AddNomineeDialog from './AddNomineeDialog'
 import { Evaluation, Organization, Participant, Progression, Role } from '../../../api/models'
 import NominationTable from './NominationTable'
 import { useCreateParticipantMutation, useParticipantsQuery } from './NominationGQL'
-import { calcProgressionStatus } from '../../../utils/ProgressionStatus'
 import { participantCanProgressEvaluation } from '../../../utils/RoleBasedAccess'
 import { useAzureUniqueId } from '../../../utils/Variables'
 
@@ -100,7 +99,6 @@ const NominationView = ({ evaluation, onNextStep }: NominationViewProps) => {
 
             <NominationTable
                 participants={participants}
-                currentProgressionStatus={calcProgressionStatus(Progression.Nomination, evaluation.progression)}
             />
 
             <AddNomineeDialog


### PR DESCRIPTION
This PR solves several issues with who and when different actions could be performed in the Nomination step. It formalises the privilege of Adding new Participants, deleting participants and progressing the evaluation past the Nomination stage:

 - **Add Participant**:  `Facilitator` and `OrganizationLead` can add participants, regardless of which progression the Evaluation is at.
 - **Delete Participants**: `Facilitators` and `OrganizationLead` can delete participants, but only when the Evaluation is still at `Nomination`.
 - **Progress Evaluation**: `Facilitators` can progress evaluation from `Nomination` to `Individual`.
 
 Additional safeguards are added to restrict non-members of the Evaluation from performing any of the above mutations. That was possible prior to this PR.