### PR TITLE
Fixed bug where new note was not listed

### DIFF
--- a/frontend/src/components/Action/QuestionActionsList.tsx
+++ b/frontend/src/components/Action/QuestionActionsList.tsx
@@ -21,7 +21,7 @@ const QuestionActionsList = ({ question, participants }: Props) => {
     const [isEditSidebarOpen, setIsEditSidebarOpen] = useState<boolean>(false)
     const [isCreateSidebarOpen, setIsCreateSidebarOpen] = useState<boolean>(false)
     const [isConfirmDeleteDialogOpen, setIsConfirmDeleteDialogOpen] = useState<boolean>(false)
-    const [actionToEditId, setActionToEditId] = useState<string | undefined>()
+    const [actionIdToEdit, setActionIdToEdit] = useState<string | undefined>()
     const [actionToDelete, setActionToDelete] = useState<string | undefined>()
     const actions = [...question.actions]
 
@@ -29,13 +29,13 @@ const QuestionActionsList = ({ question, participants }: Props) => {
 
     const openActionEditSidebar = (action: Action) => {
         setIsEditSidebarOpen(true)
-        setActionToEditId(action.id)
+        setActionIdToEdit(action.id)
     }
 
     const onClose = () => {
         setIsEditSidebarOpen(false)
         setIsCreateSidebarOpen(false)
-        setActionToEditId(undefined)
+        setActionIdToEdit(undefined)
     }
 
     return (
@@ -105,9 +105,9 @@ const QuestionActionsList = ({ question, participants }: Props) => {
                     })}
                 {actions.length === 0 && <Typography italic>No actions added</Typography>}
             </Box>
-            {actionToEditId !== undefined && (
+            {actionIdToEdit !== undefined && (
                 <ActionEditSidebarWithApi
-                    action={actions.find(a => a.id === actionToEditId)!}
+                    action={actions.find(a => a.id === actionIdToEdit)!}
                     isOpen={isEditSidebarOpen}
                     onClose={onClose}
                     connectedQuestion={question}

--- a/frontend/src/components/ActionTable/ActionTable.tsx
+++ b/frontend/src/components/ActionTable/ActionTable.tsx
@@ -51,13 +51,20 @@ const SortIcon = styled(Icon)<IconProps>`
 interface Props {
     actionsWithAdditionalInfo: ActionWithAdditionalInfo[]
     personDetailsList: PersonDetails[]
-    onClickAction: (action: Action) => void
+    onClickAction: (actionId: string) => void
     showEvaluations?: boolean
     projects?: Context[]
     isFetchingProjects?: boolean
 }
 
-const ActionTable = ({ onClickAction, actionsWithAdditionalInfo, personDetailsList, showEvaluations = false, projects, isFetchingProjects = false }: Props) => {
+const ActionTable = ({
+    onClickAction,
+    actionsWithAdditionalInfo,
+    personDetailsList,
+    showEvaluations = false,
+    projects,
+    isFetchingProjects = false,
+}: Props) => {
     const [sortDirection, setSortDirection] = useState<SortDirection>('none')
     const [columnToSortBy, setColumnToSortBy] = useState<Column>()
 
@@ -126,68 +133,72 @@ const ActionTable = ({ onClickAction, actionsWithAdditionalInfo, personDetailsLi
 
     return (
         <>
-            {!isFetchingProjects && <Table style={{ width: '100%' }}>
-                <Head>
-                    <Row>
-                        {actionTableColumns
-                            .filter(
-                                col =>
-                                    (col.name === 'Evaluation' && showEvaluations) || 
-                                    (col.name === 'Project' && projects) || 
-                                    (col.name !== 'Evaluation' && col.name !== 'Project')
-                            )
-                            .map(column => {
-                                const isSelected = columnToSortBy ? column.name === columnToSortBy.name : false
-                                return (
-                                    <Cell
-                                        key={column.name}
-                                        onClick={() => {
-                                            setSortOn(column)
-                                        }}
-                                        sort={isSelected ? sortDirection : 'none'}
-                                    >
-                                        {column.name}
-                                        <SortIcon
-                                            name={sortDirection === 'descending' ? 'chevron_up' : 'chevron_down'}
-                                            isSelected={isSelected}
-                                        />
-                                    </Cell>
+            {!isFetchingProjects && (
+                <Table style={{ width: '100%' }}>
+                    <Head>
+                        <Row>
+                            {actionTableColumns
+                                .filter(
+                                    col =>
+                                        (col.name === 'Evaluation' && showEvaluations) ||
+                                        (col.name === 'Project' && projects) ||
+                                        (col.name !== 'Evaluation' && col.name !== 'Project')
                                 )
-                            })}
-                    </Row>
-                </Head>
-                <Body>
-                    {sortedActions.map(({ action, barrier, organization }) => {
-                        const priority = action.priority
-                        const priorityFormatted = priority.substring(0, 1) + priority.substring(1).toLowerCase()
-                        const assignedTo = assignedPersonDetails(action)
+                                .map(column => {
+                                    const isSelected = columnToSortBy ? column.name === columnToSortBy.name : false
+                                    return (
+                                        <Cell
+                                            key={column.name}
+                                            onClick={() => {
+                                                setSortOn(column)
+                                            }}
+                                            sort={isSelected ? sortDirection : 'none'}
+                                        >
+                                            {column.name}
+                                            <SortIcon
+                                                name={sortDirection === 'descending' ? 'chevron_up' : 'chevron_down'}
+                                                isSelected={isSelected}
+                                            />
+                                        </Cell>
+                                    )
+                                })}
+                        </Row>
+                    </Head>
+                    <Body>
+                        {sortedActions.map(({ action, barrier, organization }) => {
+                            const priority = action.priority
+                            const priorityFormatted = priority.substring(0, 1) + priority.substring(1).toLowerCase()
+                            const assignedTo = assignedPersonDetails(action)
 
-                        return (
-                            <Row key={action.id}>
-                                <Cell
-                                    onClick={() => onClickAction(action)}
-                                    style={{ color: tokens.colors.interactive.primary__resting.rgba, cursor: 'pointer' }}
-                                >
-                                    {action.title}
-                                </Cell>
-                                {projects && <Cell>{getFusionProjectName(projects, action.question.evaluation.project.fusionProjectId)}</Cell>}
-                                {showEvaluations && <Cell>{action.question.evaluation.name}</Cell>}
-                                <Cell>{barrierToString(barrier)}</Cell>
-                                <Cell>{organizationToString(organization)}</Cell>
-                                <Cell>{action.completed ? 'Yes' : 'No'}</Cell>
-                                <Cell>
-                                    <PriorityDisplay>
-                                        <PriorityIndicator priority={action.priority} />
-                                        <Typography style={{ marginLeft: '10px' }}>{priorityFormatted}</Typography>
-                                    </PriorityDisplay>
-                                </Cell>
-                                <Cell>{assignedTo ? assignedTo.name : 'Unknown User'}</Cell>
-                                <Cell>{new Date(action.dueDate).toLocaleDateString()}</Cell>
-                            </Row>
-                        )
-                    })}
-                </Body>
-            </Table>}
+                            return (
+                                <Row key={action.id}>
+                                    <Cell
+                                        onClick={() => onClickAction(action.id)}
+                                        style={{ color: tokens.colors.interactive.primary__resting.rgba, cursor: 'pointer' }}
+                                    >
+                                        {action.title}
+                                    </Cell>
+                                    {projects && (
+                                        <Cell>{getFusionProjectName(projects, action.question.evaluation.project.fusionProjectId)}</Cell>
+                                    )}
+                                    {showEvaluations && <Cell>{action.question.evaluation.name}</Cell>}
+                                    <Cell>{barrierToString(barrier)}</Cell>
+                                    <Cell>{organizationToString(organization)}</Cell>
+                                    <Cell>{action.completed ? 'Yes' : 'No'}</Cell>
+                                    <Cell>
+                                        <PriorityDisplay>
+                                            <PriorityIndicator priority={action.priority} />
+                                            <Typography style={{ marginLeft: '10px' }}>{priorityFormatted}</Typography>
+                                        </PriorityDisplay>
+                                    </Cell>
+                                    <Cell>{assignedTo ? assignedTo.name : 'Unknown User'}</Cell>
+                                    <Cell>{new Date(action.dueDate).toLocaleDateString()}</Cell>
+                                </Row>
+                            )
+                        })}
+                    </Body>
+                </Table>
+            )}
         </>
     )
 }

--- a/frontend/src/components/ActionTable/ActionTableForOneUserWithApi.tsx
+++ b/frontend/src/components/ActionTable/ActionTableForOneUserWithApi.tsx
@@ -65,8 +65,8 @@ const ActionTableForOneUserWithApi = ({ azureUniqueId }: Props) => {
     const [projects, setProjects] = useState<Context[]>()
     const [isFetchingProject, setIsFetchingProject] = useState<boolean>(true)
     const [isEditSidebarOpen, setIsEditSidebarOpen] = useState<boolean>(false)
-    const [actionToEditId, setActionToEditId] = useState<string>('')
-    const actionToEdit = actionsWithAdditionalInfo.find(actionWithInfo => actionWithInfo.action.id === actionToEditId)
+    const [actionIdToEdit, setActionIdToEdit] = useState<string>('')
+    const actionToEdit = actionsWithAdditionalInfo.find(actionWithInfo => actionWithInfo.action.id === actionIdToEdit)
 
     useEffect(() => {
         apiClients.context.getContextsAsync().then(projects => {
@@ -77,12 +77,12 @@ const ActionTableForOneUserWithApi = ({ azureUniqueId }: Props) => {
 
     const onClose = () => {
         setIsEditSidebarOpen(false)
-        setActionToEditId('')
+        setActionIdToEdit('')
     }
 
     const openEditActionPanel = (actionId: string) => {
         setIsEditSidebarOpen(true)
-        setActionToEditId(actionId)
+        setActionIdToEdit(actionId)
     }
 
     return (
@@ -95,7 +95,7 @@ const ActionTableForOneUserWithApi = ({ azureUniqueId }: Props) => {
                 projects={projects}
                 isFetchingProjects={isFetchingProject}
             />
-            {actionToEditId !== '' && actionToEdit !== undefined && (
+            {actionIdToEdit !== '' && actionToEdit !== undefined && (
                 <ActionEditSidebarWithApi
                     action={actionToEdit.action}
                     isOpen={isEditSidebarOpen}

--- a/frontend/src/components/ActionTable/ActionTableForOneUserWithApi.tsx
+++ b/frontend/src/components/ActionTable/ActionTableForOneUserWithApi.tsx
@@ -65,7 +65,8 @@ const ActionTableForOneUserWithApi = ({ azureUniqueId }: Props) => {
     const [projects, setProjects] = useState<Context[]>()
     const [isFetchingProject, setIsFetchingProject] = useState<boolean>(true)
     const [isEditSidebarOpen, setIsEditSidebarOpen] = useState<boolean>(false)
-    const [actionToEdit, setActionToEdit] = useState<ActionWithAdditionalInfo | undefined>()
+    const [actionToEditId, setActionToEditId] = useState<string>('')
+    const actionToEdit = actionsWithAdditionalInfo.find(actionWithInfo => actionWithInfo.action.id === actionToEditId)
 
     useEffect(() => {
         apiClients.context.getContextsAsync().then(projects => {
@@ -76,13 +77,12 @@ const ActionTableForOneUserWithApi = ({ azureUniqueId }: Props) => {
 
     const onClose = () => {
         setIsEditSidebarOpen(false)
-        setActionToEdit(undefined)
+        setActionToEditId('')
     }
 
-    const openEditActionPanel = (action: Action) => {
-        const newActionToEdit = actionsWithAdditionalInfo.find(actionWithInfo => actionWithInfo.action.id === action.id)!
+    const openEditActionPanel = (actionId: string) => {
         setIsEditSidebarOpen(true)
-        setActionToEdit(newActionToEdit)
+        setActionToEditId(actionId)
     }
 
     return (
@@ -95,7 +95,7 @@ const ActionTableForOneUserWithApi = ({ azureUniqueId }: Props) => {
                 projects={projects}
                 isFetchingProjects={isFetchingProject}
             />
-            {actionToEdit !== undefined && (
+            {actionToEditId !== '' && actionToEdit !== undefined && (
                 <ActionEditSidebarWithApi
                     action={actionToEdit.action}
                     isOpen={isEditSidebarOpen}

--- a/frontend/src/components/ActionTable/ActionTableWithApi.tsx
+++ b/frontend/src/components/ActionTable/ActionTableWithApi.tsx
@@ -39,17 +39,17 @@ const ActionTableWithApi = ({ evaluations }: Props) => {
 
     const { personDetailsList } = useAllPersonDetailsAsync(allAzureUniqueIds)
     const [isEditSidebarOpen, setIsEditSidebarOpen] = useState<boolean>(false)
-    const [aqeToEdit, setAqeToEdit] = useState<ActionQuestionAndEvaluation | undefined>()
+    const [actionToEditId, setActionToEditId] = useState<string>('')
+    const actionQuestionAndEvaluation = actionQuestionAndEvaluations.find(aqe => aqe.action.id === actionToEditId)
 
     const onClose = () => {
         setIsEditSidebarOpen(false)
-        setAqeToEdit(undefined)
+        setActionToEditId('')
     }
 
-    const openEditActionPanel = (action: Action) => {
-        const newAqeToEdit = actionQuestionAndEvaluations.find(aqe => aqe.action.id === action.id)!
+    const openEditActionPanel = (actionId: string) => {
         setIsEditSidebarOpen(true)
-        setAqeToEdit(newAqeToEdit)
+        setActionToEditId(actionId)
     }
 
     const actionsWithAdditionalInfo = actionQuestionAndEvaluations.map(aqe => {
@@ -63,13 +63,13 @@ const ActionTableWithApi = ({ evaluations }: Props) => {
                 personDetailsList={personDetailsList}
                 onClickAction={openEditActionPanel}
             />
-            {aqeToEdit !== undefined && (
+            {actionToEditId !== '' && actionQuestionAndEvaluation !== undefined && (
                 <ActionEditSidebarWithApi
-                    action={aqeToEdit.action}
+                    action={actionQuestionAndEvaluation.action}
                     isOpen={isEditSidebarOpen}
                     onClose={onClose}
-                    connectedQuestion={aqeToEdit.question}
-                    possibleAssignees={aqeToEdit.evaluation.participants}
+                    connectedQuestion={actionQuestionAndEvaluation.question}
+                    possibleAssignees={actionQuestionAndEvaluation.evaluation.participants}
                 />
             )}
         </Box>

--- a/frontend/src/components/ActionTable/ActionTableWithApi.tsx
+++ b/frontend/src/components/ActionTable/ActionTableWithApi.tsx
@@ -39,17 +39,17 @@ const ActionTableWithApi = ({ evaluations }: Props) => {
 
     const { personDetailsList } = useAllPersonDetailsAsync(allAzureUniqueIds)
     const [isEditSidebarOpen, setIsEditSidebarOpen] = useState<boolean>(false)
-    const [actionToEditId, setActionToEditId] = useState<string>('')
-    const actionQuestionAndEvaluation = actionQuestionAndEvaluations.find(aqe => aqe.action.id === actionToEditId)
+    const [actionIdToEdit, setActionIdToEdit] = useState<string>('')
+    const actionQuestionAndEvaluation = actionQuestionAndEvaluations.find(aqe => aqe.action.id === actionIdToEdit)
 
     const onClose = () => {
         setIsEditSidebarOpen(false)
-        setActionToEditId('')
+        setActionIdToEdit('')
     }
 
     const openEditActionPanel = (actionId: string) => {
         setIsEditSidebarOpen(true)
-        setActionToEditId(actionId)
+        setActionIdToEdit(actionId)
     }
 
     const actionsWithAdditionalInfo = actionQuestionAndEvaluations.map(aqe => {
@@ -63,7 +63,7 @@ const ActionTableWithApi = ({ evaluations }: Props) => {
                 personDetailsList={personDetailsList}
                 onClickAction={openEditActionPanel}
             />
-            {actionToEditId !== '' && actionQuestionAndEvaluation !== undefined && (
+            {actionIdToEdit !== '' && actionQuestionAndEvaluation !== undefined && (
                 <ActionEditSidebarWithApi
                     action={actionQuestionAndEvaluation.action}
                     isOpen={isEditSidebarOpen}


### PR DESCRIPTION
**The bug**: In the action list on either the Dashboard (1), or in the Follow-up tab (2),

(1)
![image](https://user-images.githubusercontent.com/1130244/130635003-b5ba45a1-5e56-498b-8174-a2ee59771433.png)


(2)
![image](https://user-images.githubusercontent.com/1130244/130634939-2a13d3b4-053d-4df3-9507-4343acade66d.png)

when clicking on an action to open it in the side panel, and then writing a note, the note will not appear in the list of notes beneath the input field, even though the saved icon appears and the note seems to be saved. This problem does not happen when opening an action in the side panel in the questions view (3)

(3)
![image](https://user-images.githubusercontent.com/1130244/130635329-ef2e19ea-2295-4922-8728-a84d26fe4eb9.png)

**This fix:** The problem was that we were sending a copy of the action to the side panel, and this copy had the old list of notes which then would not list the new note. Now, the action in the side panel is refreshed every time the component is refreshed, and will thus have the newest data.
