### PR TITLE
Don't update author on shared answers

### DIFF
--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -162,7 +162,7 @@ namespace api.GQL
             try
             {
                 answer = _answerService.GetAnswer(question, currentUser, progression);
-                _answerService.UpdateAnswer(answer, severity, text, currentUser);
+                _answerService.UpdateAnswer(answer, severity, text);
             }
             catch (NotFoundInDBException)
             {

--- a/backend/api/Services/AnswerService.cs
+++ b/backend/api/Services/AnswerService.cs
@@ -91,8 +91,7 @@ namespace api.Services
 
         public Answer UpdateAnswer(Answer answer,
                                    Severity severity,
-                                   string text,
-                                   Participant author)
+                                   string text)
         {
             if (answer == null)
             {
@@ -101,7 +100,6 @@ namespace api.Services
 
             answer.Severity = severity;
             answer.Text = text;
-            answer.AnsweredBy = author;
 
             _context.Answers.Update(answer);
             _context.SaveChanges();

--- a/backend/tests/Services/AnswerService.cs
+++ b/backend/tests/Services/AnswerService.cs
@@ -127,7 +127,7 @@ namespace tests
             string answerId = answer.Id;
 
             string newText = "some different test answer";
-            answerService.UpdateAnswer(answer, Severity.High, newText, participant);
+            answerService.UpdateAnswer(answer, Severity.High, newText);
 
             Answer resultingAnswer = answerService.GetAnswer(answerId);
             Assert.Equal(newText, resultingAnswer.Text);


### PR DESCRIPTION
This commit corrects an issue where some older evaluation configurations
could provoke a uniqueness violation in the database. Ultimately
resulting in the end-user being unable to update an answer.

The uniqueness requirement for an entry in the dB's Answer table is that
the combination of the fields QuestionId, Progression, and AnsweredById
must be unique. This requirement is broken in older evaluations where
there are recorded several answers for the same Progression (Workshop or
Follow-up).

In the current production code, which support shared answers, the first
answer recorded at Workshop or Follow-up is shared among all users
(Facilitators). In effect there exist only a single answer for a
question in Workshop and Follow-up. However, in evaluations created
prior to the introduction of shared answers, each users had their own
answers. There is no backport for this, and like for new evaluations all
users share the first answers. The other answers are considered legacy
and are unreachable.

The problem occurs when a participant that have an legacy answer in the
database tries to update the currently shared answer. This update
attempts to change the author of the shared answer to the current user.
Which, from the db's point of view means that the same user have 2
different answers. And this breaks the uniqueness requirement, causing
the update to fail.

There are several ways to solve this issue. One would be to clean the
database by removing all legacy answers, but this is both dangerous and
tedious. Another way could be to add a new table for shared answers,
which support multiple author. That would also require a backport that
transform old answers into shared answers when applicable.

This commit solves the issue by not updating the author when updating
answers. I.e. from this commit onward the original author will always
stay the author, as opposed to prior to this commit where the latest
editor is recorded as the author. Both of these are technically wrong,
but the author is never used by the client for shared answers anyways.