### PR TITLE
Allow everyone to view all evaluations

### DIFF
--- a/frontend/src/components/Action/EditForm/ActionEditForm.tsx
+++ b/frontend/src/components/Action/EditForm/ActionEditForm.tsx
@@ -28,6 +28,7 @@ interface Props {
     isClosingRemarkSaved: boolean
     apiErrorClosingRemark: string
     apiErrorAction: string
+    disableEditAction: boolean
 }
 
 const ActionEditForm = ({
@@ -41,6 +42,7 @@ const ActionEditForm = ({
     createClosingRemark,
     apiErrorClosingRemark,
     apiErrorAction,
+    disableEditAction,
 }: Props) => {
     const [title, setTitle] = useState<string>((action && action.title) || '')
     const [titleValidity, setTitleValidity] = useState<Validity>('default')
@@ -60,6 +62,7 @@ const ActionEditForm = ({
         title: personDetails.name,
         key: personDetails.azureUniqueId,
         isSelected: personDetails.azureUniqueId === assignedToId,
+        isDisabled: disableEditAction
     }))
 
     const createdDateString = new Date(action.createDate).toLocaleDateString()
@@ -177,6 +180,7 @@ const ActionEditForm = ({
                         variant={titleValidity}
                         helperText={titleValidity === 'error' ? 'required' : ''}
                         helperIcon={titleValidity === 'error' ? ErrorIcon : <></>}
+                        disabled={disableEditAction}
                     />
                 </Grid>
                 <Grid item xs={5}>
@@ -193,6 +197,7 @@ const ActionEditForm = ({
                         label="Due date"
                         onChange={newDate => setDueDate(newDate !== null ? newDate : new Date())}
                         selectedDate={dueDate}
+                        disabled={disableEditAction}
                     />
                 </Grid>
                 <Grid item xs={3}>
@@ -220,6 +225,7 @@ const ActionEditForm = ({
                         onSelect={option => {
                             setPriority(option.key as Priority)
                         }}
+                        disabled={disableEditAction}
                     />
                 </Grid>
                 <Grid item xs={12}>
@@ -239,6 +245,7 @@ const ActionEditForm = ({
                         }}
                         variant="default"
                         style={{ height: 150 }}
+                        disabled={disableEditAction}
                     />
                 </Grid>
                 {!completed && (
@@ -249,7 +256,7 @@ const ActionEditForm = ({
                                 setCompleteActionViewOpen(true)
                                 setCompletingReason('')
                             }}
-                            disabled={completeActionViewOpen}
+                            disabled={completeActionViewOpen || disableEditAction}
                             data-testid="complete_action_button"
                         >
                             Complete action

--- a/frontend/src/components/Action/EditForm/ActionEditSidebar.tsx
+++ b/frontend/src/components/Action/EditForm/ActionEditSidebar.tsx
@@ -10,6 +10,8 @@ import { SavingState } from '../../../utils/Variables'
 import { useAllPersonDetailsAsync, useEffectNotOnMount } from '../../../utils/hooks'
 import NotesAndClosingRemarksList from './NotesAndClosingRemarksList'
 import NoteCreateForm from './NoteCreateForm'
+import { useParticipant } from '../../../globals/contexts'
+import { participantCanEditAction } from '../../../utils/RoleBasedAccess'
 
 const WRITE_DELAY_MS = 1000
 
@@ -56,6 +58,8 @@ const ActionEditSidebar = ({
     const [savingState, setSavingState] = useState<SavingState>(SavingState.None)
     const [delayedAction, setDelayedAction] = useState<Action | undefined>(undefined)
     const notesAndClosingRemarks: (Note | ClosingRemark)[] = action.notes.map(note => note)
+
+    const participant = useParticipant()
 
     if (action.closingRemarks !== undefined) {
         action.closingRemarks.forEach(closingRemark => {
@@ -138,6 +142,7 @@ const ActionEditSidebar = ({
                         isClosingRemarkSaved={isClosingRemarkSaved}
                         apiErrorClosingRemark={apiErrorClosingRemark}
                         apiErrorAction={apiErrorAction}
+                        disableEditAction={!participantCanEditAction(participant)}
                     />
                     {apiErrorAction && (
                         <div style={{ marginTop: 20 }}>
@@ -149,7 +154,12 @@ const ActionEditSidebar = ({
                             <TextArea value={apiErrorNote} onChange={() => {}} />
                         </div>
                     )}
-                    <NoteCreateForm text={note} onChange={onChangeNote} onCreateClick={onCreateNote} disabled={isNoteSaving} />
+                    <NoteCreateForm
+                        text={note}
+                        onChange={onChangeNote}
+                        onCreateClick={onCreateNote}
+                        disabled={isNoteSaving || !participantCanEditAction(participant)}
+                    />
                     <NotesAndClosingRemarksList notesAndClosingRemarks={notesAndClosingRemarks} participantsDetails={personDetailsList} />
                 </div>
             )}

--- a/frontend/src/components/Action/QuestionActionsList.tsx
+++ b/frontend/src/components/Action/QuestionActionsList.tsx
@@ -11,6 +11,8 @@ import PriorityIndicator from './PriorityIndicator'
 import ActionEditSidebarWithApi from './EditForm/ActionEditSidebarWithApi'
 import ActionCreateSidebarWithApi from './CreateForm/ActionCreateSidebarWithApi'
 import ConfirmationDialog from './../ConfirmationDialog'
+import { useParticipant } from '../../globals/contexts'
+import { participantCanCreateAction, participantCanDeleteAction } from '../../utils/RoleBasedAccess'
 
 interface Props {
     question: Question
@@ -26,6 +28,7 @@ const QuestionActionsList = ({ question, participants, deleteAction, errorDeleti
     const [actionIdToEdit, setActionIdToEdit] = useState<string | undefined>()
     const [actionToDelete, setActionToDelete] = useState<string | undefined>()
     const actions = [...question.actions]
+    const participant = useParticipant()
 
     const openActionEditSidebar = (action: Action) => {
         setIsEditSidebarOpen(true)
@@ -47,12 +50,12 @@ const QuestionActionsList = ({ question, participants, deleteAction, errorDeleti
                             Actions
                         </Typography>
                     </Box>
-                    <Box>
+                    {participantCanCreateAction(participant) && <Box>
                         <Button variant="ghost" onClick={() => setIsCreateSidebarOpen(true)}>
                             <Icon data={add}></Icon>
                             Add action
                         </Button>
-                    </Box>
+                    </Box>}
                 </Box>
                 {actions
                     .sort((a1, a2) => {
@@ -90,7 +93,7 @@ const QuestionActionsList = ({ question, participants, deleteAction, errorDeleti
                                             </Box>
                                         )}
                                     </Box>
-                                    <IconButton
+                                    {participantCanDeleteAction(participant) && <IconButton
                                         data-testid={`delete_action_button_${action.id}`}
                                         onClick={() => {
                                             setIsConfirmDeleteDialogOpen(true)
@@ -98,7 +101,7 @@ const QuestionActionsList = ({ question, participants, deleteAction, errorDeleti
                                         }}
                                     >
                                         <DeleteIcon />
-                                    </IconButton>
+                                    </IconButton>}
                                 </Box>
                             </div>
                         )

--- a/frontend/src/components/QuestionItem.tsx
+++ b/frontend/src/components/QuestionItem.tsx
@@ -17,14 +17,14 @@ interface Props {
 
 
 const QuestionItem = ({ question, viewProgression, disable, displayActions = false, onQuestionSummarySelected }: Props) => {
-    const { azureUniqueId } = useParticipant()
+    const participant = useParticipant()
 
     const useSharedAnswer = useSharedFacilitatorAnswer(viewProgression)
     const answer = findCorrectAnswer(
         question,
         viewProgression,
         useSharedAnswer,
-        azureUniqueId
+        participant
     )
 
     return (

--- a/frontend/src/components/QuestionsList.tsx
+++ b/frontend/src/components/QuestionsList.tsx
@@ -17,14 +17,14 @@ type Props = {
 }
 
 const QuestionsList = ({ questions, viewProgression, disable, displayActions, onQuestionSummarySelected, severityFilter, organizationFilter }: Props) => {
-    const { azureUniqueId: currentUserAzureUniqueId } = useParticipant()
+    const participant = useParticipant()
 
     const severityFilteredQuestions = severityFilter !== undefined
         ? questions.filter(q =>
             hasSeverity(
                 q,
                 severityFilter,
-                currentUserAzureUniqueId,
+                participant,
                 viewProgression
             )
         )

--- a/frontend/src/components/helpers.ts
+++ b/frontend/src/components/helpers.ts
@@ -1,14 +1,17 @@
 import { Context } from '@equinor/fusion'
-import { Question, Progression, Role, Severity } from '../api/models'
+import { Question, Progression, Role, Severity, Participant } from '../api/models'
 import { SeverityCount } from '../utils/Severity'
 
-export const findCorrectAnswer = (question: Question, viewProgression: Progression, useFacilitatorAnswer: boolean, userId: string) => {
+export const findCorrectAnswer = (question: Question, viewProgression: Progression, useFacilitatorAnswer: boolean, participant: Participant | undefined) => {
     const answers = question.answers.filter(a => a.progression === viewProgression)
+    if (!participant) {
+        return undefined
+    }
 
     if (useFacilitatorAnswer) {
         return answers.find(a => a.answeredBy?.role === Role.Facilitator)
     } else {
-        return answers.find(a => a.answeredBy?.azureUniqueId === userId)
+        return answers.find(a => a.answeredBy?.azureUniqueId === participant.azureUniqueId)
     }
 }
 

--- a/frontend/src/globals/contexts.ts
+++ b/frontend/src/globals/contexts.ts
@@ -6,11 +6,8 @@ export const CurrentParticipantContext = createContext<Participant | undefined>(
 export const EvaluationContext = createContext<Evaluation | undefined>(undefined)
 export const ProjectContext = createContext<Project | undefined>(undefined)
 
-export const useParticipant = (): Participant => {
+export const useParticipant = (): Participant | undefined => {
     const participant = useContext(CurrentParticipantContext)
-    if (participant === undefined) {
-        throw new Error(`You might not be a participant on this evaluation. No participant provided for context. `)
-    }
     return participant
 }
 

--- a/frontend/src/utils/QuestionAndAnswerUtils.ts
+++ b/frontend/src/utils/QuestionAndAnswerUtils.ts
@@ -1,4 +1,4 @@
-import { Answer, Organization, Progression, Question, Severity } from '../api/models'
+import { Answer, Organization, Participant, Progression, Question, Severity } from '../api/models'
 import { findCorrectAnswer, useSharedFacilitatorAnswer } from '../components/helpers'
 
 export const checkIfAnswerFilled = (answer: Answer): boolean => {
@@ -16,12 +16,12 @@ export const getFilledUserAnswersForProgression = (questions: Question[], progre
     return participantAnswers.filter(a => checkIfAnswerFilled(a))
 }
 
-export const hasSeverity = (question: Question, severityFilter: Severity[], AzureUniqueId: string, viewProgression: Progression) => {
+export const hasSeverity = (question: Question, severityFilter: Severity[], participant: Participant | undefined, viewProgression: Progression) => {
     if (severityFilter.length === 0) {
         return true
     } else {
         const useSharedAnswer = useSharedFacilitatorAnswer(viewProgression)
-        const answer = findCorrectAnswer(question, viewProgression, useSharedAnswer, AzureUniqueId)
+        const answer = findCorrectAnswer(question, viewProgression, useSharedAnswer, participant)
         const severity = (answer && answer.severity) || Severity.Na
         return severityFilter.includes(severity)
     }

--- a/frontend/src/utils/RoleBasedAccess.ts
+++ b/frontend/src/utils/RoleBasedAccess.ts
@@ -7,7 +7,10 @@ import {Answer, Participant, Progression, Role} from "../api/models"
  * Participants and ReadOnly are not allowed to read other peoples _Individual_
  * answers.
  */
-export const participantCanReadAnswer = (participant: Participant, answer: Answer) => {
+export const participantCanReadAnswer = (participant: Participant | undefined, answer: Answer) => {
+    if (!participant) {
+        return false
+    }
     switch (participant.role) {
         case Role.Facilitator: // Intentional fall-through
         case Role.OrganizationLead:
@@ -25,15 +28,18 @@ export const participantCanReadAnswer = (participant: Participant, answer: Answe
 
 
 /* Role-based rule for adding another Participant to the Evaluation */
-export const participantCanAddParticipant = (participantRole: Role) => {
+export const participantCanAddParticipant = (participant: Participant | undefined) => {
     /* Currently this share the same access as for deleting Participants */
-    return participantCanDeleteParticipant(participantRole)
+    return participantCanDeleteParticipant(participant)
 }
 
 
 /* Role-based rule for deleting another Participant from the Evaluation */
-export const participantCanDeleteParticipant = (participantRole: Role) => {
-    switch (participantRole) {
+export const participantCanDeleteParticipant = (participant: Participant | undefined) => {
+    if (!participant) {
+        return false
+    }
+    switch (participant.role) {
         case Role.Facilitator: // Intentional fall-through
         case Role.OrganizationLead:
             return true
@@ -47,8 +53,163 @@ export const participantCanDeleteParticipant = (participantRole: Role) => {
 
 
 /* Role-based rule for progressing an Evaluation */
-export const participantCanProgressEvaluation = (participantRole: Role) => {
-    switch (participantRole) {
+export const participantCanProgressEvaluation = (participant: Participant | undefined) => {
+    if (!participant) {
+        return false
+    }
+    switch (participant.role) {
+        case Role.Facilitator:
+            return true
+        case Role.OrganizationLead:
+        case Role.Participant: // Intentional fall-through
+        case Role.ReadOnly:
+            return false
+        default:
+            return false
+    }
+}
+
+/* Role-based rule for creating an action */
+export const participantCanCreateAction = (participant: Participant | undefined) => {
+    if (!participant) {
+        return false
+    }
+    switch (participant.role) {
+        case Role.Facilitator:
+        case Role.OrganizationLead:
+        case Role.Participant: // Intentional fall-through
+            return true
+        case Role.ReadOnly:
+            return false
+        default:
+            return false
+    }
+}
+
+/* Role-based rule for editing an action */
+export const participantCanEditAction = (participant: Participant | undefined) => {
+    if (!participant) {
+        return false
+    }
+    switch (participant.role) {
+        case Role.Facilitator:
+        case Role.OrganizationLead:
+        case Role.Participant: // Intentional fall-through
+            return true
+        case Role.ReadOnly:
+            return false
+        default:
+            return false
+    }
+}
+
+/* Role-based rule for deleting an action */
+export const participantCanDeleteAction = (participant: Participant | undefined) => {
+    if (!participant) {
+        return false
+    }
+    switch (participant.role) {
+        case Role.Facilitator:
+        case Role.OrganizationLead:
+        case Role.Participant: // Intentional fall-through
+            return true
+        case Role.ReadOnly:
+            return false
+        default:
+            return false
+    }
+}
+
+/* Role-based rule for access to the workshop summary */
+export const participantCanViewWorkshopSummary = (participant: Participant | undefined) => {
+    if (!participant) {
+        return true
+    }
+    switch (participant.role) {
+        case Role.Facilitator:
+        case Role.OrganizationLead:
+        case Role.Participant: // Intentional fall-through
+        case Role.ReadOnly:
+            return true
+        default:
+            return false
+    }
+}
+
+/* Role-based rule for editing the workshop summary */
+export const participantCanEditWorkshopSummary = (participant: Participant | undefined) => {
+    if (!participant) {
+        return false
+    }
+    switch (participant.role) {
+        case Role.Facilitator:
+            return true
+        case Role.OrganizationLead:
+        case Role.Participant: // Intentional fall-through
+        case Role.ReadOnly:
+            return false
+        default:
+            return false
+    }
+}
+
+/* Role-based rule for input to Individual */
+export const participantCanInputIndividual = (participant: Participant | undefined) => {
+    if (!participant) {
+        return false
+    }
+    switch (participant.role) {
+        case Role.Facilitator:
+        case Role.OrganizationLead:
+        case Role.Participant: // Intentional fall-through
+            return true
+        case Role.ReadOnly:
+            return false
+        default:
+            return false
+    }
+}
+
+/* Role-based rule for input to Preparation */
+export const participantCanInputPreparation = (participant: Participant | undefined) => {
+    if (!participant) {
+        return false
+    }
+    switch (participant.role) {
+        case Role.Facilitator:
+        case Role.OrganizationLead:
+            return true
+        case Role.Participant: // Intentional fall-through
+        case Role.ReadOnly:
+            return false
+        default:
+            return false
+    }
+}
+
+/* Role-based rule for input to Workshop */
+export const participantCanInputWorkshop = (participant: Participant | undefined) => {
+    if (!participant) {
+        return false
+    }
+    switch (participant.role) {
+        case Role.Facilitator:
+            return true
+        case Role.OrganizationLead:
+        case Role.Participant: // Intentional fall-through
+        case Role.ReadOnly:
+            return false
+        default:
+            return false
+    }
+}
+
+/* Role-based rule for input to FollowUp */
+export const participantCanInputFollowUp = (participant: Participant | undefined) => {
+    if (!participant) {
+        return false
+    }
+    switch (participant.role) {
         case Role.Facilitator:
             return true
         case Role.OrganizationLead:

--- a/frontend/src/utils/disableComponents.ts
+++ b/frontend/src/utils/disableComponents.ts
@@ -1,0 +1,55 @@
+import { Evaluation, Participant, Progression, Role } from "../api/models"
+import { participantCanInputFollowUp, participantCanInputIndividual, participantCanInputPreparation, participantCanInputWorkshop, participantCanProgressEvaluation } from "./RoleBasedAccess"
+
+ export const disableProgression = (evaluation: Evaluation, participant: Participant | undefined, viewProgression: Progression) => {
+    if (evaluation.progression !== viewProgression) {
+        return true
+    }
+    return !participantCanProgressEvaluation(participant)
+}
+
+export const disableCompleteSwitch = (participant: Participant | undefined, evaluation: Evaluation, viewProgression: Progression) => {
+    if (!participant) {
+        return true
+    }
+    if (evaluation.progression !== viewProgression || participant.progression !== viewProgression) {
+        return true
+    }
+    switch (viewProgression) {
+        case Progression.Individual:
+            return !participantCanInputIndividual(participant)
+        case Progression.Preparation:
+            return !participantCanInputPreparation(participant)
+        case Progression.Workshop:
+            return !participantCanInputWorkshop(participant)
+        default:
+            return true
+    }
+}
+
+export const disableAnswer = (participant: Participant | undefined, evaluation: Evaluation, viewProgression: Progression) => {
+    if (!participant) {
+        return true
+    }
+    if (evaluation.progression !== viewProgression || participant.progression !== viewProgression) {
+        /* In Individual and Workshop, only facilitators can answer questions
+         if the evaluation or the participant is not on the current progression */
+        if (viewProgression === Progression.Individual || viewProgression === Progression.Workshop) {
+            return participant.role !== Role.Facilitator
+        }
+        return true
+    }
+    switch (viewProgression) {
+        case Progression.Individual:
+            return !participantCanInputIndividual(participant)
+        case Progression.Preparation:
+            return !participantCanInputPreparation(participant)
+        case Progression.Workshop:
+            return !participantCanInputWorkshop(participant)
+        case Progression.FollowUp:
+            return !participantCanInputFollowUp(participant)
+        default:
+            return true
+    }
+    
+}

--- a/frontend/src/views/Evaluation/EvaluationView.tsx
+++ b/frontend/src/views/Evaluation/EvaluationView.tsx
@@ -66,7 +66,6 @@ const EvaluationView = ({ evaluation, onProgressEvaluationClick, onProgressParti
                     stepKey={Progression.Workshop}
                 >
                     <WorkshopTabs
-                        allowedRoles={[Role.Facilitator]}
                         evaluation={evaluation}
                     >
                         <WorkshopView

--- a/frontend/src/views/Evaluation/Nomination/NominationTable.tsx
+++ b/frontend/src/views/Evaluation/Nomination/NominationTable.tsx
@@ -97,11 +97,7 @@ const disableDelete = (evaluation: Evaluation, azureUniqueId: string) => {
 
     const loggedInUser = evaluation.participants.find(p => p.azureUniqueId === azureUniqueId)
 
-    if (!loggedInUser) {
-        return true
-    }
-
-    return !participantCanDeleteParticipant(loggedInUser.role)
+    return !participantCanDeleteParticipant(loggedInUser)
 }
 
 interface NominationTableProps {

--- a/frontend/src/views/Evaluation/Workshop/WorkshopSummary.tsx
+++ b/frontend/src/views/Evaluation/Workshop/WorkshopSummary.tsx
@@ -1,31 +1,27 @@
 import AnswerMarkdownForm from '../../../components/QuestionAndAnswer/AnswerMarkdownForm'
 import { SavingState } from '../../../utils/Variables'
 import SaveIndicator from '../../../components/SaveIndicator'
-
+import Disabler from '../../../components/Disabler'
 
 interface WorkshopSummaryProps {
-    localSummary: string,
+    localSummary: string
     onChange: (value: string) => void
     savingState: SavingState
+    disable: boolean
 }
 
-const WorkshopSummary = ({
-    localSummary,
-    onChange,
-    savingState,
-}: WorkshopSummaryProps) => {
+const WorkshopSummary = ({ localSummary, onChange, savingState, disable }: WorkshopSummaryProps) => {
     return (
         <>
             <h3>Summary</h3>
-            <p>
-                As facilitator you can use this field to write up a summary of
-                the workshop.
-            </p>
-            <AnswerMarkdownForm
-                markdown={localSummary === '' ? ' ' : localSummary /*Fixes backspace error in markdown editor*/}
-                onMarkdownChange={onChange}
-                disabled={false}
-            />
+            <p>As facilitator you can use this field to write up a summary of the workshop.</p>
+            <Disabler disable={disable}>
+                <AnswerMarkdownForm
+                    markdown={localSummary === '' ? ' ' : localSummary /*Fixes backspace error in markdown editor*/}
+                    onMarkdownChange={onChange}
+                    disabled={false}
+                />
+            </Disabler>
             <SaveIndicator savingState={savingState} />
         </>
     )

--- a/frontend/src/views/Evaluation/Workshop/WorkshopSummaryWithApi.tsx
+++ b/frontend/src/views/Evaluation/Workshop/WorkshopSummaryWithApi.tsx
@@ -7,16 +7,14 @@ import { useEffectNotOnMount } from '../../../utils/hooks'
 import { SavingState } from '../../../utils/Variables'
 import WorkshopSummary from './WorkshopSummary'
 
-
 const WRITE_DELAY_MS = 1000
 
 interface WorkshopSummaryWithApiProps {
     evaluation: Evaluation
+    disable: boolean
 }
 
-const WorkshopSummaryWithApi = ({
-    evaluation
-}: React.PropsWithChildren<WorkshopSummaryWithApiProps>) => {
+const WorkshopSummaryWithApi = ({ evaluation, disable }: React.PropsWithChildren<WorkshopSummaryWithApiProps>) => {
     const [localSummary, setLocalSummary] = useState(evaluation.summary ?? '')
     const [savingState, setSavingState] = useState(SavingState.None)
     const { setSummary, loading, error } = useSummaryMutation()
@@ -56,13 +54,14 @@ const WorkshopSummaryWithApi = ({
     }
 
     return (
-        <>
-            <WorkshopSummary
-                localSummary={localSummary}
-                onChange={onChange}
-                savingState={savingState}
+        <div style={{ padding: '30px' }}>
+            <WorkshopSummary 
+                localSummary={localSummary} 
+                onChange={onChange} 
+                savingState={savingState} 
+                disable={disable} 
             />
-        </>
+        </div>
     )
 }
 

--- a/frontend/src/views/Evaluation/Workshop/WorkshopTabs.tsx
+++ b/frontend/src/views/Evaluation/Workshop/WorkshopTabs.tsx
@@ -5,19 +5,15 @@ import { Evaluation, Role } from '../../../api/models'
 import { useParticipant } from '../../../globals/contexts'
 import { StyledTabPanel } from '../../../components/StyledTabs'
 import WorkshopSummaryWithApi from './WorkshopSummaryWithApi'
+import { participantCanEditWorkshopSummary, participantCanViewWorkshopSummary } from '../../../utils/RoleBasedAccess'
 
 const { TabList, Tab, TabPanels } = Tabs
 
 interface WorkshopTabsProps {
     evaluation: Evaluation
-    allowedRoles: Role[]
 }
 
-const WorkshopTabs = ({
-    children,
-    allowedRoles,
-    evaluation,
-}: React.PropsWithChildren<WorkshopTabsProps>) => {
+const WorkshopTabs = ({ children, evaluation }: React.PropsWithChildren<WorkshopTabsProps>) => {
     const [activeTab, setActiveTab] = useState(0)
     const participant = useParticipant()
 
@@ -25,14 +21,12 @@ const WorkshopTabs = ({
         <Tabs activeTab={activeTab} onChange={setActiveTab}>
             <TabList>
                 <Tab>Questionaire</Tab>
-                <Tab>Workshop Summary</Tab>
+                <Tab disabled={!participantCanViewWorkshopSummary(participant)}>Workshop Summary</Tab>
             </TabList>
             <TabPanels>
                 <StyledTabPanel>{children}</StyledTabPanel>
                 <StyledTabPanel>
-                    {allowedRoles.includes(participant.role) && (
-                        <WorkshopSummaryWithApi evaluation={evaluation} />
-                    )}
+                    <WorkshopSummaryWithApi evaluation={evaluation} disable={!participantCanEditWorkshopSummary(participant)} />
                 </StyledTabPanel>
             </TabPanels>
         </Tabs>


### PR DESCRIPTION
Changes in this PR:
* A participant who is not a part of an evaluation is now `undefined`. This means that `useParticipant()` now returns either a `Participant` or an `undefined`.
* Some of the functions that have had `azureUniqueId` as an argument now has a participant as an argument. This makes it possible to check if a participant is `undefined` before the id of the participant is being used.
* There has been created functions that deal with access to various components and operations. Some of these functions replace boolean expressions that were difficult to read, and some of them present new functionality that ensure that an `undefined` participant cannot do any operations in an evaluation. For instance, an `undefined` participant cannot delete, add or edit actions.
* Everyone, including the `undefined` participants, can view the content of the workshop summary tab on the workshop stage, but only facilitators can edit the summary. 

Potential test cases
* A user that is not a member of an evaluation, aka an `undefined` participant, should be able to view the content of the evaluation which means that the user can:
     - click on the evaluation and not get an error
     - display the content of all of the tabs on all stages of the evaluation
     - click on an action, and display the content
* The `undefined` user should not be able to: 
     - answer any questions
     - add, edit or delete actions
     - add notes to actions
     - view the answers in the `AnswerSummarySidebar`
     - edit the workshop summary on the workshop stage
     - progress the evaluation to the next stage
     - check the complete switch on different stages of the evaluation

* The workshop summary tab on the workshop stage
     - a facilitator is the only one who can edit the workshop summary on the workshop stage
     - all other roles can only view the summary.

* Facilitators, OrgLeads and Participants can create, edit and delete actions

* Only Facilitators can click "Finish `stage`" and progress the evaluation. This only applies if the progress of the evaluation is the same as the stage in the current view

* If the progression of the evaluation and the user is on the Individual stage, then on the Individual stage Facilitators, OrgLeads and Participants can write answers. Facilitators can also write answers on the Workshop stage even if the progression of the evaluation and the user is not on the Individual stage.

* If the progression of the evaluation and the user is on the Preparation stage, then on the Preparation stage Facilitators and OrgLeads can write answers. 

* Facilitators are the only ones who can write answers on the Workshop stage. Facilitators can also write answers on the Workshop stage even if the progression of the evaluation and the user is not on the Workshop stage.

* If the progression of the evaluation and the user is on the Follow up stage, then on the Follow up stage only Facilitators can write answers. 

* If the progression of the evaluation and the user is on the Individual stage, then on the Individual stage Facilitators, OrgLeads and Participants can click the complete switch.

* If the progression of the evaluation and the user is on the Preparation stage, then on the Preparation stage Facilitators and OrgLeads can click the complete switch.

* If the progression of the evaluation and the user is on the Workshop stage, then on the Workshop stage Facilitators can click the complete switch.