### PR TITLE
Add Role-based restriction to backend mutations

### DIFF
--- a/backend/api/Authorization/AuthService.cs
+++ b/backend/api/Authorization/AuthService.cs
@@ -9,7 +9,6 @@ namespace api.Authorization
     public interface IAuthService
     {
         public string GetOID();
-        public void AssertIsFacilitator(string evaluationId);
     }
 
     public class AuthService : IAuthService
@@ -32,18 +31,6 @@ namespace api.Authorization
             var httpContext = _contextAccessor.HttpContext;
             string oid = httpContext.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
             return oid;
-        }
-
-        public void AssertIsFacilitator(string evaluationId)
-        {
-            string oid = GetOID();
-            Evaluation evaluation = _evaluationService.GetEvaluation(evaluationId);
-            Participant participant = _participantService.GetParticipant(oid, evaluation);
-            if (participant.Role != Role.Facilitator)
-            {
-                throw new UnauthorizedAccessException($"Current user is not Facilitator");
-
-            }
         }
     }
 }

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -133,6 +133,24 @@ namespace api.GQL
             Role[] canBePerformedBy = { Role.Facilitator, Role.OrganizationLead };
             AssertCanPerformMutation(evaluation, canBePerformedBy);
 
+            Participant subject = _participantService.GetParticipant(participantId);
+
+            /* Safeguard against deleting the last Facilitator */
+            if (subject.Role.Equals(Role.Facilitator))
+            {
+                int facilitators = evaluation.Participants
+                    .Where(p => p.Role.Equals(Role.Facilitator))
+                    .Count()
+                ;
+
+                if (facilitators < 2)
+                {
+                    string msg = "Cannot delete last Facilitator in Evaluation";
+                    throw new InvalidOperationException(msg);
+
+                }
+            }
+
             return _participantService.Remove(participantId);
         }
 

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -217,6 +217,10 @@ namespace api.GQL
             /* Note that no related fields are loaded */
             IQueryable<Action> queryableAction = _actionService.GetAction(actionId);
             Action action = queryableAction.First();
+            Evaluation evaluation = queryableAction.Select(q => q.Question.Evaluation).First();
+
+            Role[] canBePerformedBy = { Role.Facilitator };
+            AssertCanPerformMutation(evaluation, canBePerformedBy);
 
              _actionService.Remove(action);
              return action;

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -104,6 +104,9 @@ namespace api.GQL
             Evaluation evaluation = _evaluationService.GetEvaluation(evaluationId);
             Participant participant = _participantService.GetParticipant(azureUniqueId, evaluation);
 
+            Role[] canBePerformedBy = { Role.Facilitator, Role.OrganizationLead, Role.Participant };
+            AssertCanPerformMutation(evaluation, canBePerformedBy);
+
             Participant progressedParticipant = _participantService.ProgressParticipant(participant, newProgression);
 
             return progressedParticipant;

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -190,6 +190,9 @@ namespace api.GQL
             Question question = queryableQuestion.First();
             Evaluation evaluation = queryableQuestion.Select(q => q.Evaluation).First();
 
+            Role[] canBePerformedBy = { Role.Facilitator, Role.Participant, Role.OrganizationLead };
+            AssertCanPerformMutation(evaluation, canBePerformedBy);
+
             Participant assignedTo = _participantService.GetParticipant(assignedToId);
 
             return _actionService.Create(CurrentUser(evaluation), assignedTo, description, dueDate, title, priority, question);

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -112,6 +112,10 @@ namespace api.GQL
         public Participant CreateParticipant(string azureUniqueId, string evaluationId, Organization organization, Role role)
         {
             Evaluation evaluation = _evaluationService.GetEvaluation(evaluationId);
+
+            Role[] canBePerformedBy = { Role.Facilitator, Role.OrganizationLead };
+            AssertCanPerformMutation(evaluation, canBePerformedBy);
+
             return _participantService.Create(azureUniqueId, evaluation, organization, role);
         }
 

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -202,6 +202,10 @@ namespace api.GQL
         {
             IQueryable<Action> queryableAction = _actionService.GetAction(actionId);
             Action action = queryableAction.First();
+            Evaluation evaluation = queryableAction.Select(q => q.Question.Evaluation).First();
+
+            Role[] canBePerformedBy = { Role.Facilitator, Role.Participant, Role.OrganizationLead };
+            AssertCanPerformMutation(evaluation, canBePerformedBy);
 
             Participant assignedTo = _participantService.GetParticipant(assignedToId);
 

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -238,12 +238,6 @@ namespace api.GQL
             return _noteService.Create(CurrentUser(evaluation), text, action);
         }
 
-        public Note EditNote(string noteId, string text)
-        {
-            Note note = _noteService.GetNote(noteId);
-            return _noteService.EditNote(note, text);
-        }
-
         public ClosingRemark CreateClosingRemark(string actionId, string text)
         {
             IQueryable<Action> queryableAction = _actionService.GetAction(actionId);

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -121,6 +121,15 @@ namespace api.GQL
 
         public Participant DeleteParticipant(string participantId)
         {
+            Evaluation evaluation = _participantService.GetAll()
+                .Where(p => p.Id.Equals(participantId))
+                .Select(p => p.Evaluation)
+                .First()
+            ;
+
+            Role[] canBePerformedBy = { Role.Facilitator, Role.OrganizationLead };
+            AssertCanPerformMutation(evaluation, canBePerformedBy);
+
             return _participantService.Remove(participantId);
         }
 

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -165,6 +165,10 @@ namespace api.GQL
             IQueryable<Question> queryableQuestion = _questionService.GetQuestion(questionId);
             Question question = queryableQuestion.First();
             Evaluation evaluation = queryableQuestion.Select(q => q.Evaluation).First();
+
+            Role[] canBePerformedBy = { Role.Facilitator, Role.Participant, Role.OrganizationLead };
+            AssertCanPerformMutation(evaluation, canBePerformedBy);
+
             Participant currentUser = CurrentUser(evaluation);
             Answer answer;
             try

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -244,6 +244,9 @@ namespace api.GQL
             Action action = queryableAction.First();
             Evaluation evaluation = queryableAction.Select(a => a.Question.Evaluation).First();
 
+            Role[] canBePerformedBy = { Role.Facilitator, Role.Participant, Role.OrganizationLead };
+            AssertCanPerformMutation(evaluation, canBePerformedBy);
+
             return _closingRemarkService.Create(CurrentUser(evaluation), text, action);
         }
 

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -232,6 +232,9 @@ namespace api.GQL
             Action action = queryableAction.First();
             Evaluation evaluation = queryableAction.Select(a => a.Question.Evaluation).First();
 
+            Role[] canBePerformedBy = { Role.Facilitator, Role.Participant, Role.OrganizationLead };
+            AssertCanPerformMutation(evaluation, canBePerformedBy);
+
             return _noteService.Create(CurrentUser(evaluation), text, action);
         }
 

--- a/backend/tests/DbContextTestSetup.cs
+++ b/backend/tests/DbContextTestSetup.cs
@@ -5,6 +5,7 @@ using Microsoft.Data.Sqlite;
 
 using api.Authorization;
 using api.Context;
+using api.Models;
 
 namespace tests
 {
@@ -39,7 +40,7 @@ namespace tests
         {
             return "1";
         }
-        public void AssertIsFacilitator(string evaluationId)
+        public void AssertCanPerformMutation(Evaluation evaluation, Role[] allowdRoles)
         {
             // Do nothing
         }

--- a/backend/tests/DbContextTestSetup.cs
+++ b/backend/tests/DbContextTestSetup.cs
@@ -34,15 +34,23 @@ namespace tests
         }
     }
 
-    class MockAuthService : IAuthService
+    public class MockAuthService : IAuthService
     {
+        private string _loggedInUser = "1";
+
+        public void LoginUser(string azureUniqueId)
+        {
+            _loggedInUser = azureUniqueId;
+        }
+
+        public void LoginUser(Participant participant)
+        {
+            _loggedInUser = participant.AzureUniqueId;
+        }
+
         public string GetOID()
         {
-            return "1";
-        }
-        public void AssertCanPerformMutation(Evaluation evaluation, Role[] allowdRoles)
-        {
-            // Do nothing
+            return _loggedInUser;
         }
     }
 }

--- a/backend/tests/GQL/Mutation.cs
+++ b/backend/tests/GQL/Mutation.cs
@@ -199,6 +199,11 @@ namespace tests
             return action;
         }
 
+        protected void DeleteAction(string actionId)
+        {
+            _mutation.DeleteAction(actionId);
+        }
+
         /* Helper methods */
 
         protected int NumberOfParticipants(Evaluation evaluation)

--- a/backend/tests/GQL/Mutation.cs
+++ b/backend/tests/GQL/Mutation.cs
@@ -59,5 +59,70 @@ namespace tests
 
             _project = _projectService.Create("Project");
         }
+
+        /* Mutation wrappers with default values */
+
+        protected Evaluation CreateEvaluation(
+            string name = null,
+            string projectId = null,
+            string previousEvaluationId = null)
+        {
+            if (name == null)
+            {
+                name = Randomize.String();
+            }
+
+            if (projectId == null)
+            {
+                projectId = _project.Id;
+            }
+
+            if (previousEvaluationId == null)
+            {
+                previousEvaluationId = "";
+            }
+
+            Evaluation evaluation =  _mutation.CreateEvaluation(
+                name: name,
+                projectId: projectId,
+                previousEvaluationId:  previousEvaluationId
+            );
+
+            return evaluation;
+        }
+
+        protected Participant CreateParticipant(
+            Evaluation evaluation,
+            string azureUniqueId = null,
+            Organization? organization = null,
+            Role? role = null)
+        {
+            if (azureUniqueId == null)
+            {
+                azureUniqueId = Randomize.Integer().ToString();
+            }
+
+            Participant participant = _mutation.CreateParticipant(
+                azureUniqueId: azureUniqueId,
+                evaluationId: evaluation.Id,
+                organization: organization.GetValueOrDefault(Randomize.Organization()),
+                role: role.GetValueOrDefault(Randomize.Role())
+            );
+
+            return participant;
+        }
+
+        /* Helper methods */
+
+        protected int NumberOfParticipants(Evaluation evaluation)
+        {
+            int participants = _participantService
+                .GetAll()
+                .Where(p => p.Evaluation == evaluation)
+                .Count()
+            ;
+
+            return participants;
+        }
     }
 }

--- a/backend/tests/GQL/Mutation.cs
+++ b/backend/tests/GQL/Mutation.cs
@@ -222,6 +222,24 @@ namespace tests
             return note;
         }
 
+        protected ClosingRemark CreateClosingRemark(
+            string actionId,
+            string text = null)
+        {
+
+            if (text == null)
+            {
+                text = Randomize.String();
+            }
+
+            ClosingRemark remark = _mutation.CreateClosingRemark(
+                actionId: actionId,
+                text: text
+            );
+
+            return remark;
+        }
+
         /* Helper methods */
 
         protected int NumberOfParticipants(Evaluation evaluation)
@@ -266,6 +284,17 @@ namespace tests
             ;
 
             return notes;
+        }
+
+        protected int NumberOfClosingRemarks(Action action)
+        {
+            int remarks = _closingRemarkService
+                .GetAll()
+                .Where(a => a.Action == action)
+                .Count()
+            ;
+
+            return remarks;
         }
 
         protected Question GetFirstQuestion(Evaluation evaluation)

--- a/backend/tests/GQL/Mutation.cs
+++ b/backend/tests/GQL/Mutation.cs
@@ -112,6 +112,28 @@ namespace tests
             return participant;
         }
 
+        protected Answer SetAnswer(
+            string questionId,
+            Severity? severity = null,
+            string text = null,
+            Progression? progression = null)
+        {
+
+            if (text == null)
+            {
+                text = Randomize.String();
+            }
+
+            Answer answer= _mutation.SetAnswer(
+                    questionId: questionId,
+                    severity: severity.GetValueOrDefault(Randomize.Severity()),
+                    text: text,
+                    progression: progression.GetValueOrDefault(Randomize.Progression())
+            );
+
+            return answer;
+        }
+
         /* Helper methods */
 
         protected int NumberOfParticipants(Evaluation evaluation)
@@ -123,6 +145,26 @@ namespace tests
             ;
 
             return participants;
+        }
+
+        protected int NumberOfAnswers(Question question)
+        {
+            int answers = _answerService
+                .GetAll()
+                .Where(a => a.Question == question)
+                .Count()
+            ;
+
+            return answers;
+        }
+
+        protected Question GetFirstQuestion(Evaluation evaluation)
+        {
+            return _questionService
+                .GetAll()
+                .Where(q => q.Evaluation.Id == evaluation.Id)
+                .First()
+            ;
         }
     }
 }

--- a/backend/tests/GQL/Mutation.cs
+++ b/backend/tests/GQL/Mutation.cs
@@ -204,6 +204,24 @@ namespace tests
             _mutation.DeleteAction(actionId);
         }
 
+        protected Note CreateNote(
+            string actionId,
+            string text = null)
+        {
+
+            if (text == null)
+            {
+                text = Randomize.String();
+            }
+
+            Note note = _mutation.CreateNote(
+                actionId: actionId,
+                text: text
+            );
+
+            return note;
+        }
+
         /* Helper methods */
 
         protected int NumberOfParticipants(Evaluation evaluation)
@@ -237,6 +255,17 @@ namespace tests
             ;
 
             return actions;
+        }
+
+        protected int NumberOfNotes(Action action)
+        {
+            int notes = _noteService
+                .GetAll()
+                .Where(a => a.Action == action)
+                .Count()
+            ;
+
+            return notes;
         }
 
         protected Question GetFirstQuestion(Evaluation evaluation)

--- a/backend/tests/GQL/Mutation.cs
+++ b/backend/tests/GQL/Mutation.cs
@@ -67,7 +67,7 @@ namespace tests
         {
             Project project = _projectService.Create("ProgressEvaluationToFollowup");
             Evaluation evaluation = _evaluationService.Create("ProgressEvaluationToFollowup", project, "");
-            Participant participant = _participantService.Create("ProgressEvaluationToFollowup", evaluation, Organization.All, Role.Facilitator);
+            Participant participant = _participantService.Create("1", evaluation, Organization.All, Role.Facilitator);
 
             List<Question> questions = _questionService.CreateBulk(_questionTemplateService.GetAll().ToList(), evaluation);
             _answerService.Create(participant, questions[0], Severity.High, "test_answer_0", Progression.Workshop);

--- a/backend/tests/GQL/Mutation.cs
+++ b/backend/tests/GQL/Mutation.cs
@@ -164,6 +164,41 @@ namespace tests
             return action;
         }
 
+        protected Action EditAction(
+            string actionId,
+            string assignedToId,
+            string description = null,
+            System.DateTimeOffset? dueDate = null,
+            Priority? priority = null,
+            string title = null,
+            bool onHold = false,
+            bool completed = false)
+        {
+
+            if (title == null)
+            {
+                title = Randomize.String();
+            }
+
+            if (description == null)
+            {
+                description = Randomize.String();
+            }
+
+            Action action = _mutation.EditAction(
+                actionId: actionId,
+                assignedToId: assignedToId,
+                description: description,
+                dueDate: dueDate.GetValueOrDefault(System.DateTimeOffset.Now),
+                priority: priority.GetValueOrDefault(Randomize.Priority()),
+                title: title,
+                onHold: onHold,
+                completed: completed
+            );
+
+            return action;
+        }
+
         /* Helper methods */
 
         protected int NumberOfParticipants(Evaluation evaluation)

--- a/backend/tests/GQL/Mutation.cs
+++ b/backend/tests/GQL/Mutation.cs
@@ -4,7 +4,6 @@ using api.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System;
 using System.Linq;
 using System.Collections.Generic;
 using Xunit;
@@ -134,6 +133,37 @@ namespace tests
             return answer;
         }
 
+        protected Action CreateAction(
+            string questionId,
+            string assignedToId,
+            string description = null,
+            System.DateTimeOffset? dueDate = null,
+            Priority? priority = null,
+            string title = null)
+        {
+
+            if (title == null)
+            {
+                title = Randomize.String();
+            }
+
+            if (description == null)
+            {
+                description = Randomize.String();
+            }
+
+            Action action = _mutation.CreateAction(
+                questionId: questionId,
+                assignedToId: assignedToId,
+                description: description,
+                dueDate: dueDate.GetValueOrDefault(System.DateTimeOffset.Now),
+                priority: priority.GetValueOrDefault(Randomize.Priority()),
+                title: title
+            );
+
+            return action;
+        }
+
         /* Helper methods */
 
         protected int NumberOfParticipants(Evaluation evaluation)
@@ -156,6 +186,17 @@ namespace tests
             ;
 
             return answers;
+        }
+
+        protected int NumberOfActions(Question question)
+        {
+            int actions = _actionService
+                .GetAll()
+                .Where(a => a.Question == question)
+                .Count()
+            ;
+
+            return actions;
         }
 
         protected Question GetFirstQuestion(Evaluation evaluation)

--- a/backend/tests/GQL/Mutations/CreateAction.cs
+++ b/backend/tests/GQL/Mutations/CreateAction.cs
@@ -1,0 +1,89 @@
+using Xunit;
+using System;
+using System.Linq;
+
+using api.Models;
+using api.Services;
+using api.GQL;
+
+
+namespace tests
+{
+    public class CreateActionMutation : MutationTest
+    {
+        private readonly Evaluation _evaluation;
+        private readonly Participant _facilitator;
+        private readonly Participant _organizationLead;
+        private readonly Participant _participant;
+        private readonly Participant _readonly;
+        private readonly Question _question;
+
+        public CreateActionMutation() {
+            _evaluation = CreateEvaluation();
+            _facilitator = _evaluation.Participants.First();
+            _authService.LoginUser(_facilitator);
+
+            _organizationLead = CreateParticipant(_evaluation, role: Role.OrganizationLead);
+            _participant = CreateParticipant(_evaluation, role: Role.Participant);
+            _readonly = CreateParticipant(_evaluation, role: Role.ReadOnly);
+            _question = GetFirstQuestion(_evaluation);
+        }
+
+        /* Tests */
+
+        [Fact]
+        public void FacilitatorCanUseMutation()
+        {
+            AssertCanCreate(_facilitator);
+        }
+
+        [Fact]
+        public void OrganizationLeadCanUseMutation()
+        {
+            AssertCanCreate(_organizationLead);
+        }
+
+        [Fact]
+        public void ParticipantIsCanUseMutation()
+        {
+            AssertCanCreate(_participant);
+        }
+
+        [Fact]
+        public void ReadOnlyIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_readonly.AzureUniqueId);
+        }
+
+        [Fact]
+        public void NonParcipantIsUnauthorized()
+        {
+            string AzureUniqueId = Randomize.Integer().ToString();
+            AssertIsNotAuthorized(AzureUniqueId);
+        }
+
+        /* Helper methods */
+
+        private void AssertCanCreate(Participant user)
+        {
+            _authService.LoginUser(user);
+            int answers = NumberOfActions(_question);
+            CreateAction(
+                questionId: _question.Id,
+                assignedToId: Randomize.Value<Participant>(_evaluation.Participants).Id
+            );
+            Assert.True(NumberOfActions(_question) == answers + 1);
+        }
+
+        private void AssertIsNotAuthorized(string azureUniqueId)
+        {
+            _authService.LoginUser(azureUniqueId);
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                CreateAction(
+                    questionId: _question.Id,
+                    assignedToId: Randomize.Value<Participant>(_evaluation.Participants).Id
+                )
+            );
+        }
+    }
+}

--- a/backend/tests/GQL/Mutations/CreateClosingRemark.cs
+++ b/backend/tests/GQL/Mutations/CreateClosingRemark.cs
@@ -1,0 +1,94 @@
+using Xunit;
+using System;
+using System.Linq;
+
+using api.Models;
+using api.Services;
+using api.GQL;
+
+
+namespace tests
+{
+    public class CreateClosingRemarkMutation : MutationTest
+    {
+        private readonly Evaluation _evaluation;
+        private readonly Participant _facilitator;
+        private readonly Participant _organizationLead;
+        private readonly Participant _participant;
+        private readonly Participant _readonly;
+        private readonly Question _question;
+        private readonly api.Models.Action _action;
+
+        public CreateClosingRemarkMutation() {
+            _evaluation = CreateEvaluation();
+            _facilitator = _evaluation.Participants.First();
+            _authService.LoginUser(_facilitator);
+
+            _organizationLead = CreateParticipant(_evaluation, role: Role.OrganizationLead);
+            _participant = CreateParticipant(_evaluation, role: Role.Participant);
+            _readonly = CreateParticipant(_evaluation, role: Role.ReadOnly);
+            _question = GetFirstQuestion(_evaluation);
+            _action = CreateAction(
+                questionId: _question.Id,
+                assignedToId: Randomize.Value<Participant>(_evaluation.Participants).Id
+            );
+        }
+
+        /* Tests */
+
+        [Fact]
+        public void FacilitatorCanUseMutation()
+        {
+            AssertCanCreate(_facilitator);
+        }
+
+        [Fact]
+        public void OrganizationLeadCanUseMutation()
+        {
+            AssertCanCreate(_organizationLead);
+        }
+
+        [Fact]
+        public void ParticipantCanUseMutation()
+        {
+            AssertCanCreate(_participant);
+        }
+
+        [Fact]
+        public void ReadOnlyIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_readonly.AzureUniqueId);
+        }
+
+        [Fact]
+        public void NonParcipantIsUnauthorized()
+        {
+            string AzureUniqueId = Randomize.Integer().ToString();
+            AssertIsNotAuthorized(AzureUniqueId);
+        }
+
+        /* Helper methods */
+
+        private void AssertCanCreate(Participant user)
+        {
+            _authService.LoginUser(user);
+            int notes = NumberOfClosingRemarks(_action);
+            CreateClosingRemark(
+                actionId: _action.Id,
+                text: Randomize.String()
+            );
+            Assert.True(NumberOfClosingRemarks(_action) == notes + 1);
+        }
+
+        private void AssertIsNotAuthorized(string azureUniqueId)
+        {
+            _authService.LoginUser(azureUniqueId);
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                CreateClosingRemark(
+                    actionId: _action.Id,
+                    text: Randomize.String()
+                )
+            );
+        }
+    }
+}

--- a/backend/tests/GQL/Mutations/CreateNote.cs
+++ b/backend/tests/GQL/Mutations/CreateNote.cs
@@ -1,0 +1,94 @@
+using Xunit;
+using System;
+using System.Linq;
+
+using api.Models;
+using api.Services;
+using api.GQL;
+
+
+namespace tests
+{
+    public class CreateNoteMutation : MutationTest
+    {
+        private readonly Evaluation _evaluation;
+        private readonly Participant _facilitator;
+        private readonly Participant _organizationLead;
+        private readonly Participant _participant;
+        private readonly Participant _readonly;
+        private readonly Question _question;
+        private readonly api.Models.Action _action;
+
+        public CreateNoteMutation() {
+            _evaluation = CreateEvaluation();
+            _facilitator = _evaluation.Participants.First();
+            _authService.LoginUser(_facilitator);
+
+            _organizationLead = CreateParticipant(_evaluation, role: Role.OrganizationLead);
+            _participant = CreateParticipant(_evaluation, role: Role.Participant);
+            _readonly = CreateParticipant(_evaluation, role: Role.ReadOnly);
+            _question = GetFirstQuestion(_evaluation);
+            _action = CreateAction(
+                questionId: _question.Id,
+                assignedToId: Randomize.Value<Participant>(_evaluation.Participants).Id
+            );
+        }
+
+        /* Tests */
+
+        [Fact]
+        public void FacilitatorCanUseMutation()
+        {
+            AssertCanCreate(_facilitator);
+        }
+
+        [Fact]
+        public void OrganizationLeadCanUseMutation()
+        {
+            AssertCanCreate(_organizationLead);
+        }
+
+        [Fact]
+        public void ParticipantCanUseMutation()
+        {
+            AssertCanCreate(_participant);
+        }
+
+        [Fact]
+        public void ReadOnlyIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_readonly.AzureUniqueId);
+        }
+
+        [Fact]
+        public void NonParcipantIsUnauthorized()
+        {
+            string AzureUniqueId = Randomize.Integer().ToString();
+            AssertIsNotAuthorized(AzureUniqueId);
+        }
+
+        /* Helper methods */
+
+        private void AssertCanCreate(Participant user)
+        {
+            _authService.LoginUser(user);
+            int notes = NumberOfNotes(_action);
+            CreateNote(
+                actionId: _action.Id,
+                text: Randomize.String()
+            );
+            Assert.True(NumberOfNotes(_action) == notes + 1);
+        }
+
+        private void AssertIsNotAuthorized(string azureUniqueId)
+        {
+            _authService.LoginUser(azureUniqueId);
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                CreateNote(
+                    actionId: _action.Id,
+                    text: Randomize.String()
+                )
+            );
+        }
+    }
+}

--- a/backend/tests/GQL/Mutations/CreateParticipant.cs
+++ b/backend/tests/GQL/Mutations/CreateParticipant.cs
@@ -1,0 +1,86 @@
+using Xunit;
+using System;
+using System.Linq;
+
+using api.Models;
+using api.Services;
+using api.GQL;
+
+
+namespace tests
+{
+    public class CreateParticipantMutation : MutationTest
+    {
+        private readonly Evaluation _evaluation;
+        private readonly Participant _facilitator;
+        private readonly Participant _organizationLead;
+        private readonly Participant _participant;
+        private readonly Participant _readonly;
+
+        public CreateParticipantMutation() {
+            _evaluation = CreateEvaluation();
+            _facilitator = _evaluation.Participants.First();
+            _authService.LoginUser(_facilitator);
+
+            _organizationLead = CreateParticipant(_evaluation, role: Role.OrganizationLead);
+            _participant = CreateParticipant(_evaluation, role: Role.Participant);
+            _readonly = CreateParticipant(_evaluation, role: Role.ReadOnly);
+        }
+
+        /* Tests */
+
+        [Fact]
+        public void FacilitatorCanUseMutation()
+        {
+            AssertCanCreate(_facilitator);
+        }
+
+        [Fact]
+        public void OrganizationLeadCanUseMutation()
+        {
+            AssertCanCreate(_organizationLead);
+        }
+
+        [Fact]
+        public void ParticipantIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_participant);
+        }
+
+        [Fact]
+        public void ReadOnlyIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_readonly);
+        }
+
+        [Fact]
+        public void NonParcipantIsUnauthorized()
+        {
+            string AzureUniqueId = Randomize.Integer().ToString();
+            AssertIsNotAuthorized(AzureUniqueId);
+        }
+
+        /* Helper methods */
+
+        private void AssertCanCreate(Participant user)
+        {
+            _authService.LoginUser(user);
+            int participants = NumberOfParticipants(_evaluation);
+            CreateParticipant(_evaluation);
+            Assert.True(NumberOfParticipants(_evaluation) == participants + 1);
+        }
+
+        private void AssertIsNotAuthorized(string azureUniqueId)
+        {
+            _authService.LoginUser(azureUniqueId);
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                CreateParticipant(_evaluation)
+            );
+        }
+
+        private void AssertIsNotAuthorized(Participant user)
+        {
+            AssertIsNotAuthorized(user.AzureUniqueId);
+        }
+    }
+}

--- a/backend/tests/GQL/Mutations/DeleteAction.cs
+++ b/backend/tests/GQL/Mutations/DeleteAction.cs
@@ -1,0 +1,93 @@
+using Xunit;
+using System;
+using System.Linq;
+
+using api.Models;
+using api.Services;
+using api.GQL;
+
+
+namespace tests
+{
+    public class DeleteActionMutation : MutationTest
+    {
+        private readonly Evaluation _evaluation;
+        private readonly Participant _facilitator;
+        private readonly Participant _organizationLead;
+        private readonly Participant _participant;
+        private readonly Participant _readonly;
+        private readonly Question _question;
+        private readonly api.Models.Action _action;
+
+        public DeleteActionMutation() {
+            _evaluation = CreateEvaluation();
+            _facilitator = _evaluation.Participants.First();
+            _authService.LoginUser(_facilitator);
+
+            _organizationLead = CreateParticipant(_evaluation, role: Role.OrganizationLead);
+            _participant = CreateParticipant(_evaluation, role: Role.Participant);
+            _readonly = CreateParticipant(_evaluation, role: Role.ReadOnly);
+            _question = GetFirstQuestion(_evaluation);
+            _action = CreateAction(
+                questionId: _question.Id,
+                assignedToId: Randomize.Value<Participant>(_evaluation.Participants).Id
+            );
+        }
+
+        /* Tests */
+
+        [Fact]
+        public void FacilitatorCanUseMutation()
+        {
+            AssertCanDelete(_facilitator);
+        }
+
+        [Fact]
+        public void OrganizationLeadIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_organizationLead.AzureUniqueId);
+        }
+
+        [Fact]
+        public void ParticipantIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_participant.AzureUniqueId);
+        }
+
+        [Fact]
+        public void ReadOnlyIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_readonly.AzureUniqueId);
+        }
+
+        [Fact]
+        public void NonParcipantIsUnauthorized()
+        {
+            string AzureUniqueId = Randomize.Integer().ToString();
+            AssertIsNotAuthorized(AzureUniqueId);
+        }
+
+        /* Helper methods */
+
+        private void AssertCanDelete(Participant user)
+        {
+            var toDelete = CreateAction(
+                questionId: _question.Id,
+                assignedToId: Randomize.Value<Participant>(_evaluation.Participants).Id
+            );
+
+            _authService.LoginUser(user);
+            int answers = NumberOfActions(_question);
+            DeleteAction(toDelete.Id);
+            Assert.True(NumberOfActions(_question) == answers - 1);
+        }
+
+        private void AssertIsNotAuthorized(string azureUniqueId)
+        {
+            _authService.LoginUser(azureUniqueId);
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                DeleteAction(_action.Id)
+            );
+        }
+    }
+}

--- a/backend/tests/GQL/Mutations/DeleteParticipant.cs
+++ b/backend/tests/GQL/Mutations/DeleteParticipant.cs
@@ -1,0 +1,91 @@
+using Xunit;
+using System;
+using System.Linq;
+
+using api.Models;
+using api.Services;
+using api.GQL;
+
+
+namespace tests
+{
+    public class DeleteParticipantMutation : MutationTest
+    {
+        private readonly Evaluation _evaluation;
+        private readonly Participant _facilitator;
+        private readonly Participant _organizationLead;
+        private readonly Participant _participant;
+        private readonly Participant _readonly;
+
+        public DeleteParticipantMutation() {
+            _evaluation = CreateEvaluation();
+            _facilitator = _evaluation.Participants.First();
+            _authService.LoginUser(_facilitator);
+
+            _organizationLead = CreateParticipant(_evaluation, role: Role.OrganizationLead);
+            _participant = CreateParticipant(_evaluation, role: Role.Participant);
+            _readonly = CreateParticipant(_evaluation, role: Role.ReadOnly);
+        }
+
+        /* Tests */
+
+        [Fact]
+        public void FacilitatorCanUseMutation()
+        {
+            AssertCanDelete(_facilitator);
+        }
+
+        [Fact]
+        public void OrganizationLeadCanUseMutation()
+        {
+            AssertCanDelete(_organizationLead);
+        }
+
+        [Fact]
+        public void ParticipantIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_participant.AzureUniqueId);
+        }
+
+        [Fact]
+        public void ReadOnlyIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_readonly.AzureUniqueId);
+        }
+
+        [Fact]
+        public void NonParcipantIsUnauthorized()
+        {
+            string AzureUniqueId = Randomize.Integer().ToString();
+            AssertIsNotAuthorized(AzureUniqueId);
+        }
+
+        /* Helper methods */
+
+        private void AssertCanDelete(Participant user)
+        {
+            var toDelete = CreateParticipant(
+                evaluation: _evaluation,
+                azureUniqueId: Randomize.Integer().ToString()
+            );
+
+            _authService.LoginUser(user);
+            int participants = NumberOfParticipants(_evaluation);
+            _mutation.DeleteParticipant(toDelete.Id);
+            Assert.True(NumberOfParticipants(_evaluation) == participants - 1);
+        }
+
+        private void AssertIsNotAuthorized(string azureUniqueId)
+        {
+            var toDelete = CreateParticipant(
+                evaluation: _evaluation,
+                azureUniqueId: Randomize.Integer().ToString()
+            );
+
+            _authService.LoginUser(azureUniqueId);
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                _mutation.DeleteParticipant(toDelete.Id)
+            );
+        }
+    }
+}

--- a/backend/tests/GQL/Mutations/DeleteParticipant.cs
+++ b/backend/tests/GQL/Mutations/DeleteParticipant.cs
@@ -60,6 +60,36 @@ namespace tests
             AssertIsNotAuthorized(AzureUniqueId);
         }
 
+        [Fact]
+        public void CannotPerformOnNonLastFacilitator()
+        {
+            Evaluation evaluation = CreateEvaluation();
+            Participant first = evaluation.Participants.First();
+            _authService.LoginUser(first);
+            Participant second = CreateParticipant(evaluation, role: Role.Facilitator);
+
+            int participants = evaluation.Participants.Count();
+            Assert.Equal(2, participants);
+
+            _authService.LoginUser(second);
+            _mutation.DeleteParticipant(first.Id);
+
+            participants = evaluation.Participants.Count();
+            Assert.Equal(1, participants);
+        }
+
+        [Fact]
+        public void CannotPerformOnLastFacilitator()
+        {
+            Evaluation evaluation = CreateEvaluation();
+            Participant facilitator = evaluation.Participants.First();
+            _authService.LoginUser(facilitator);
+
+            Assert.Throws<InvalidOperationException>(() =>
+                _mutation.DeleteParticipant(facilitator.Id)
+            );
+        }
+
         /* Helper methods */
 
         private void AssertCanDelete(Participant user)

--- a/backend/tests/GQL/Mutations/EditAction.cs
+++ b/backend/tests/GQL/Mutations/EditAction.cs
@@ -1,0 +1,100 @@
+using Xunit;
+using System;
+using System.Linq;
+
+using api.Models;
+using api.Services;
+using api.GQL;
+
+
+namespace tests
+{
+    public class EditActionMutation : MutationTest
+    {
+        private readonly Evaluation _evaluation;
+        private readonly Participant _facilitator;
+        private readonly Participant _organizationLead;
+        private readonly Participant _participant;
+        private readonly Participant _readonly;
+        private readonly Question _question;
+        private readonly api.Models.Action _action;
+
+        public EditActionMutation() {
+            _evaluation = CreateEvaluation();
+            _facilitator = _evaluation.Participants.First();
+            _authService.LoginUser(_facilitator);
+
+            _organizationLead = CreateParticipant(_evaluation, role: Role.OrganizationLead);
+            _participant = CreateParticipant(_evaluation, role: Role.Participant);
+            _readonly = CreateParticipant(_evaluation, role: Role.ReadOnly);
+            _question = GetFirstQuestion(_evaluation);
+            _action = CreateAction(
+                questionId: _question.Id,
+                assignedToId: Randomize.Value<Participant>(_evaluation.Participants).Id
+            );
+        }
+
+        /* Tests */
+
+        [Fact]
+        public void FacilitatorCanUseMutation()
+        {
+            AssertCanEdit(_facilitator);
+        }
+
+        [Fact]
+        public void OrganizationLeadCanUseMutation()
+        {
+            AssertCanEdit(_organizationLead);
+        }
+
+        [Fact]
+        public void ParticipantIsCanUseMutation()
+        {
+            AssertCanEdit(_participant);
+        }
+
+        [Fact]
+        public void ReadOnlyIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_readonly.AzureUniqueId);
+        }
+
+        [Fact]
+        public void NonParcipantIsUnauthorized()
+        {
+            string AzureUniqueId = Randomize.Integer().ToString();
+            AssertIsNotAuthorized(AzureUniqueId);
+        }
+
+        /* Helper methods */
+
+        private void AssertCanEdit(Participant user)
+        {
+            _authService.LoginUser(user);
+            int answers = NumberOfActions(_question);
+            string description = _action.Description;
+            string actionId = _action.Id;
+
+            var action = EditAction(
+                actionId: actionId,
+                assignedToId: Randomize.Value<Participant>(_evaluation.Participants).Id,
+                description: Randomize.String()
+            );
+            Assert.True(NumberOfActions(_question) == answers);
+            Assert.True(actionId == action.Id);
+            Assert.False(description == action.Description);
+        }
+
+        private void AssertIsNotAuthorized(string azureUniqueId)
+        {
+            _authService.LoginUser(azureUniqueId);
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                EditAction(
+                    actionId: _action.Id,
+                    assignedToId: Randomize.Value<Participant>(_evaluation.Participants).Id
+                )
+            );
+        }
+    }
+}

--- a/backend/tests/GQL/Mutations/ProgressEvaluation.cs
+++ b/backend/tests/GQL/Mutations/ProgressEvaluation.cs
@@ -1,0 +1,94 @@
+using Xunit;
+using System;
+using System.Linq;
+
+using api.Models;
+using api.Services;
+using api.GQL;
+
+
+namespace tests
+{
+    public class ProgressEvaluationMutation : MutationTest
+    {
+        private readonly Evaluation _evaluation;
+        private readonly Participant _facilitator;
+        private readonly Participant _organizationLead;
+        private readonly Participant _participant;
+        private readonly Participant _readonly;
+
+        public ProgressEvaluationMutation() {
+            _evaluation = CreateEvaluation();
+            _facilitator = _evaluation.Participants.First();
+            _authService.LoginUser(_facilitator);
+
+            _organizationLead = CreateParticipant(_evaluation, role: Role.OrganizationLead);
+            _participant = CreateParticipant(_evaluation, role: Role.Participant);
+            _readonly = CreateParticipant(_evaluation, role: Role.ReadOnly);
+        }
+
+        /* Tests */
+
+        [Fact]
+        public void FacilitatorCanUseMutation()
+        {
+            AssertCanProgress(_facilitator);
+        }
+
+        [Fact]
+        public void OrganizationLeadIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_organizationLead);
+        }
+
+        [Fact]
+        public void ParticipantIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_participant);
+        }
+
+        [Fact]
+        public void ReadOnlyIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_readonly);
+        }
+
+        [Fact]
+        public void NonParcipantIsUnauthorized()
+        {
+            string AzureUniqueId = Randomize.Integer().ToString();
+            AssertIsNotAuthorized(AzureUniqueId);
+        }
+
+        /* Helper methods */
+
+        private void AssertCanProgress(Participant user)
+        {
+            _authService.LoginUser(user);
+            Progression newProgression = Randomize.Progression();
+
+            _mutation.ProgressEvaluation(
+                evaluationId: _evaluation.Id,
+                newProgression: newProgression
+            );
+
+            Assert.True(_evaluation.Progression == newProgression);
+        }
+
+        private void AssertIsNotAuthorized(string azureUniqueId)
+        {
+            _authService.LoginUser(azureUniqueId);
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                _mutation.ProgressEvaluation(
+                    evaluationId: _evaluation.Id,
+                    newProgression: Randomize.Progression()
+                )
+            );
+        }
+
+        private void AssertIsNotAuthorized(Participant user)
+        {
+            AssertIsNotAuthorized(user.AzureUniqueId);
+        }
+    }
+}

--- a/backend/tests/GQL/Mutations/ProgressParticipant.cs
+++ b/backend/tests/GQL/Mutations/ProgressParticipant.cs
@@ -1,0 +1,82 @@
+using Xunit;
+using System;
+using System.Linq;
+
+using api.Models;
+using api.Services;
+using api.GQL;
+
+
+namespace tests
+{
+    public class ProgressParticipantMutation : MutationTest
+    {
+        private readonly Evaluation _evaluation;
+        private readonly Participant _facilitator;
+        private readonly Participant _organizationLead;
+        private readonly Participant _participant;
+        private readonly Participant _readonly;
+
+        public ProgressParticipantMutation() {
+            _evaluation = CreateEvaluation();
+            _facilitator = _evaluation.Participants.First();
+            _authService.LoginUser(_facilitator);
+
+            _organizationLead = CreateParticipant(_evaluation, role: Role.OrganizationLead);
+            _participant = CreateParticipant(_evaluation, role: Role.Participant);
+            _readonly = CreateParticipant(_evaluation, role: Role.ReadOnly);
+        }
+
+        /* Tests */
+
+        [Fact]
+        public void FacilitatorCanUseMutation()
+        {
+            AssertCanProgress(_facilitator);
+        }
+
+        [Fact]
+        public void OrganizationLeadCanUseMutation()
+        {
+            AssertCanProgress(_organizationLead);
+        }
+
+        [Fact]
+        public void ParticipantCanUseMutation()
+        {
+            AssertCanProgress(_participant);
+        }
+
+        [Fact]
+        public void ReadOnlyIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_readonly);
+        }
+
+        /* Helper methods */
+
+        private void AssertCanProgress(Participant user)
+        {
+            _authService.LoginUser(user);
+            Progression newProgression = Randomize.Progression();
+
+            _mutation.ProgressParticipant(
+                evaluationId: _evaluation.Id,
+                newProgression: newProgression
+            );
+
+            Assert.True(user.Progression == newProgression);
+        }
+
+        private void AssertIsNotAuthorized(Participant user)
+        {
+            _authService.LoginUser(user.AzureUniqueId);
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                _mutation.ProgressParticipant(
+                    evaluationId: _evaluation.Id,
+                    newProgression: Randomize.Progression()
+                )
+            );
+        }
+    }
+}

--- a/backend/tests/GQL/Mutations/SetAnswer.cs
+++ b/backend/tests/GQL/Mutations/SetAnswer.cs
@@ -1,0 +1,88 @@
+using Xunit;
+using System;
+using System.Linq;
+
+using api.Models;
+using api.Services;
+using api.GQL;
+
+
+namespace tests
+{
+    public class SetAnswerMutation : MutationTest
+    {
+        private readonly Evaluation _evaluation;
+        private readonly Participant _facilitator;
+        private readonly Participant _organizationLead;
+        private readonly Participant _participant;
+        private readonly Participant _readonly;
+        private readonly Question _question;
+
+        public SetAnswerMutation() {
+            _evaluation = CreateEvaluation();
+            _facilitator = _evaluation.Participants.First();
+            _authService.LoginUser(_facilitator);
+
+            _organizationLead = CreateParticipant(_evaluation, role: Role.OrganizationLead);
+            _participant = CreateParticipant(_evaluation, role: Role.Participant);
+            _readonly = CreateParticipant(_evaluation, role: Role.ReadOnly);
+            _question = GetFirstQuestion(_evaluation);
+        }
+
+        /* Tests */
+
+        [Fact]
+        public void FacilitatorCanUseMutation()
+        {
+            AssertCanSet(_facilitator);
+        }
+
+        [Fact]
+        public void OrganizationLeadCanUseMutation()
+        {
+            AssertCanSet(_organizationLead);
+        }
+
+        [Fact]
+        public void ParticipantCanUseMutation()
+        {
+            AssertCanSet(_participant);
+        }
+
+        [Fact]
+        public void ReadOnlyIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_readonly);
+        }
+
+        [Fact]
+        public void NonParcipantIsUnauthorized()
+        {
+            string AzureUniqueId = Randomize.Integer().ToString();
+            AssertIsNotAuthorized(AzureUniqueId);
+        }
+
+        /* Helper methods */
+
+        private void AssertCanSet(Participant user)
+        {
+            _authService.LoginUser(user);
+            int answers = NumberOfAnswers(_question);
+            SetAnswer(_question.Id);
+            Assert.True(NumberOfAnswers(_question) == answers + 1);
+        }
+
+        private void AssertIsNotAuthorized(string azureUniqueId)
+        {
+            _authService.LoginUser(azureUniqueId);
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                SetAnswer(_question.Id)
+            );
+        }
+
+        private void AssertIsNotAuthorized(Participant user)
+        {
+            AssertIsNotAuthorized(user.AzureUniqueId);
+        }
+    }
+}

--- a/backend/tests/GQL/Mutations/SetSummary.cs
+++ b/backend/tests/GQL/Mutations/SetSummary.cs
@@ -1,0 +1,94 @@
+using Xunit;
+using System;
+using System.Linq;
+
+using api.Models;
+using api.Services;
+using api.GQL;
+
+
+namespace tests
+{
+    public class SetSummaryMutation: MutationTest
+    {
+        private readonly Evaluation _evaluation;
+        private readonly Participant _facilitator;
+        private readonly Participant _organizationLead;
+        private readonly Participant _participant;
+        private readonly Participant _readonly;
+
+        public SetSummaryMutation() {
+            _evaluation = CreateEvaluation();
+            _facilitator = _evaluation.Participants.First();
+            _authService.LoginUser(_facilitator);
+
+            _organizationLead = CreateParticipant(_evaluation, role: Role.OrganizationLead);
+            _participant = CreateParticipant(_evaluation, role: Role.Participant);
+            _readonly = CreateParticipant(_evaluation, role: Role.ReadOnly);
+        }
+
+        /* Tests */
+
+        [Fact]
+        public void FacilitatorCanUseMutation()
+        {
+            AssertCanSet(_facilitator);
+        }
+
+        [Fact]
+        public void OrganizationLeadIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_organizationLead);
+        }
+
+        [Fact]
+        public void ParticipantIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_participant);
+        }
+
+        [Fact]
+        public void ReadOnlyIsUnauthorized()
+        {
+            AssertIsNotAuthorized(_readonly);
+        }
+
+        [Fact]
+        public void NonParcipantIsUnauthorized()
+        {
+            string AzureUniqueId = Randomize.Integer().ToString();
+            AssertIsNotAuthorized(AzureUniqueId);
+        }
+
+        /* Helper methods */
+
+        private void AssertCanSet(Participant user)
+        {
+            _authService.LoginUser(user);
+
+            string summary = Randomize.String();
+            _mutation.SetSummary(
+                evaluationId: _evaluation.Id,
+                summary: summary
+            );
+
+            Assert.True(_evaluation.Summary == summary);
+        }
+
+        private void AssertIsNotAuthorized(string azureUniqueId)
+        {
+            _authService.LoginUser(azureUniqueId);
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                _mutation.SetSummary(
+                    evaluationId: _evaluation.Id,
+                    summary: Randomize.String()
+                )
+            );
+        }
+
+        private void AssertIsNotAuthorized(Participant user)
+        {
+            AssertIsNotAuthorized(user.AzureUniqueId);
+        }
+    }
+}

--- a/backend/tests/Randomize.cs
+++ b/backend/tests/Randomize.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+
 
 using api.Models;
 
@@ -49,6 +53,17 @@ namespace tests
         public static Severity Severity()
         {
             return RandomEnumValue<Severity>();
+        }
+
+        public static Priority Priority()
+        {
+            return RandomEnumValue<Priority>();
+        }
+
+        public static T Value<T>(ICollection<T> values)
+        {
+            int pick = random.Next(values.Count);
+            return values.ElementAt(pick);
         }
 
         private static T RandomEnumValue<T>()

--- a/backend/tests/Randomize.cs
+++ b/backend/tests/Randomize.cs
@@ -1,0 +1,50 @@
+using System;
+
+using api.Models;
+
+
+namespace tests
+{
+    public static class Randomize
+    {
+        private static Random random = new Random();
+        private static string alphanumeric =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+            "abcdefghijklmnopqrstuvwxyz" +
+            "0123456789";
+
+        public static string Integer()
+        {
+            return random.Next(Int32.MinValue, Int32.MaxValue).ToString();
+        }
+
+        /* Random alphanumeric string of 8-32 characters */
+        public static string String()
+        {
+            char[] chars = new char[random.Next(8, 32)];
+
+            for (int i = 0; i < chars.Length; i++)
+            {
+                chars[i] = alphanumeric[random.Next(alphanumeric.Length)];
+            }
+
+            return new String(chars);
+        }
+
+        public static Role Role()
+        {
+            return RandomEnumValue<Role>();
+        }
+
+        public static Organization Organization()
+        {
+            return RandomEnumValue<Organization>();
+        }
+
+        private static T RandomEnumValue<T>()
+        {
+            Array values = Enum.GetValues(typeof(T));
+            return (T)values.GetValue(random.Next(values.Length));
+        }
+    }
+}

--- a/backend/tests/Randomize.cs
+++ b/backend/tests/Randomize.cs
@@ -41,6 +41,16 @@ namespace tests
             return RandomEnumValue<Organization>();
         }
 
+        public static Progression Progression()
+        {
+            return RandomEnumValue<Progression>();
+        }
+
+        public static Severity Severity()
+        {
+            return RandomEnumValue<Severity>();
+        }
+
         private static T RandomEnumValue<T>()
         {
             Array values = Enum.GetValues(typeof(T));

--- a/frontend/cypress/integration/actions_spec.ts
+++ b/frontend/cypress/integration/actions_spec.ts
@@ -1,5 +1,5 @@
 import { EvaluationSeed } from '../support/evaluation_seed'
-import { Progression, Priority } from '../../src/api/models'
+import { Progression, Priority, Role } from '../../src/api/models'
 import { FUSION_DATE_LOCALE } from '../support/helpers'
 import { barrierToString, organizationToString } from '../../src/utils/EnumToString'
 import { Action, Note, Participant } from '../support/mocks'
@@ -130,7 +130,7 @@ describe('Actions', () => {
             ;({ seed, actionToDelete, actionToStay } = createDeleteSeed())
 
             seed.plant().then(() => {
-                const user = faker.random.arrayElement(seed.participants).user
+                const user = faker.random.arrayElement(seed.participants.filter(x => x.role === Role.Facilitator)).user
                 cy.visitEvaluation(seed.evaluationId, user)
                 evaluationPage.progressionStepLink(deleteActionFrom).click()
                 cy.contains(actionToDelete.title).should('exist')
@@ -176,6 +176,7 @@ describe('Actions', () => {
                     }
                 })
 
+                cy.login(seed.participants[0].user)
                 deleteAction()
 
                 cy.testCacheAndDB(

--- a/frontend/cypress/support/evaluation_seed.ts
+++ b/frontend/cypress/support/evaluation_seed.ts
@@ -207,39 +207,34 @@ const populateDB = (seed: EvaluationSeed) => {
             })
         })
         .then(() => {
-            cy.log(`EvaluationSeed: Progressing evaluation for creator ${seed.participants[0].user}`)
-            cy.gql(PROGRESS_PARTICIPANT, {
-                variables: {
-                    evaluationId: seed.evaluationId,
-                    newProgression: seed.participants[0].progression,
-                },
-            })
-        })
-        .then(() => {
             return seed.participants.slice(1)
         })
         .each((participant: Participant) => {
-            cy.log(`EvaluationSeed: Adding and progressing additional Participants`)
-            return cy
-                .gql(ADD_PARTICIPANT, {
+            cy.log(`EvaluationSeed: Adding Participants`)
+            cy.gql(ADD_PARTICIPANT, {
+                variables: {
+                    azureUniqueId: participant.user.id,
+                    evaluationId: seed.evaluationId,
+                    organization: participant.organization,
+                    role: participant.role,
+                },
+            }).then(res => {
+                participant.id = res.body.data.createParticipant.id
+            })
+        })
+        .then(() => {
+            return seed.participants
+        })
+        .each((participant: Participant) => {
+            cy.login(participant.user).then(() => {
+                cy.log(`EvaluationSeed: Progressing Participant`)
+                cy.gql(PROGRESS_PARTICIPANT, {
                     variables: {
-                        azureUniqueId: participant.user.id,
                         evaluationId: seed.evaluationId,
-                        organization: participant.organization,
-                        role: participant.role,
+                        newProgression: participant.progression,
                     },
                 })
-                .then(res => {
-                    participant.id = res.body.data.createParticipant.id
-                    cy.login(participant.user).then(() => {
-                        cy.gql(PROGRESS_PARTICIPANT, {
-                            variables: {
-                                evaluationId: seed.evaluationId,
-                                newProgression: participant.progression,
-                            },
-                        })
-                    })
-                })
+            })
         })
         .then(() => {
             return seed.answers

--- a/frontend/cypress/support/testdata.ts
+++ b/frontend/cypress/support/testdata.ts
@@ -20,7 +20,7 @@ export function createAction(
     this: EvaluationSeed,
     {
         assignedTo = faker.random.arrayElement(this!.participants),
-        createdBy = faker.random.arrayElement(this!.participants),
+        createdBy = faker.random.arrayElement(this!.participants.filter(x => x.role !== Role.ReadOnly)),
         // no access to questions as creation is run before plant. Reconsider?
         questionOrder = faker.datatype.number({ min: 1, max: 3 }),
         dueDate = faker.date.future(),

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -327,7 +327,6 @@ export type Mutation = {
   editAction?: Maybe<Action>;
   deleteAction?: Maybe<Action>;
   createNote?: Maybe<Note>;
-  editNote?: Maybe<Note>;
   createClosingRemark?: Maybe<ClosingRemark>;
 };
 
@@ -431,12 +430,6 @@ export type MutationDeleteActionArgs = {
 
 export type MutationCreateNoteArgs = {
   actionId?: Maybe<Scalars['String']>;
-  text?: Maybe<Scalars['String']>;
-};
-
-
-export type MutationEditNoteArgs = {
-  noteId?: Maybe<Scalars['String']>;
   text?: Maybe<Scalars['String']>;
 };
 


### PR DESCRIPTION
This PR adds role-based restrictions to all exposed mutations. Additionally it extends the current test-framework to test the new restrictions.

The test framework for Mutation testing in the backend only implements access-based tests at the moment, but it is intended to be used for further correctness testing of the mutations. However that is out of scope of this PR.

Closes #537
Closes #512