### PR TITLE
Fixed slow saving of severity

### DIFF
--- a/frontend/src/components/QuestionAndAnswer/QuestionAndAnswerForm.tsx
+++ b/frontend/src/components/QuestionAndAnswer/QuestionAndAnswerForm.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Chip } from '@equinor/fusion-components'
 import { Typography } from '@equinor/eds-core-react'
 
-import { Answer, Question } from '../../api/models'
+import { Answer, Question, Severity } from '../../api/models'
 import { Box, Grid } from '@material-ui/core'
 import AnswerSeverityForm from './AnswerSeverityForm'
 import AnswerMarkdownForm from './AnswerMarkdownForm'
@@ -15,11 +15,19 @@ interface QuestionAndAnswerFormProps {
     question: Question
     answer: Answer
     disabled: boolean
-    onAnswerChange: (answerParts: Partial<Answer>) => void
+    onAnswerTextChange: (text: string) => void
+    onSeverityChange: (severity: Severity) => void
     savingState: SavingState
 }
 
-const QuestionAndAnswerForm = ({ question, answer, disabled, onAnswerChange, savingState }: QuestionAndAnswerFormProps) => {
+const QuestionAndAnswerForm = ({
+    question,
+    answer,
+    disabled,
+    onAnswerTextChange,
+    onSeverityChange,
+    savingState,
+}: QuestionAndAnswerFormProps) => {
     return (
         <>
             <Grid container>
@@ -50,7 +58,7 @@ const QuestionAndAnswerForm = ({ question, answer, disabled, onAnswerChange, sav
                             <Box mr={5}>
                                 <AnswerSeverityForm
                                     severity={answer.severity}
-                                    onSeveritySelected={severity => onAnswerChange({ severity: severity })}
+                                    onSeveritySelected={severity => onSeverityChange(severity)}
                                     disabled={disabled}
                                 />
                             </Box>
@@ -59,7 +67,7 @@ const QuestionAndAnswerForm = ({ question, answer, disabled, onAnswerChange, sav
                                     markdown={answer.text === '' ? ' ' : answer.text /*Fixes backspace error in markdown editor*/}
                                     disabled={disabled}
                                     onMarkdownChange={text => {
-                                        onAnswerChange({ text: text })
+                                        onAnswerTextChange(text)
                                     }}
                                 />
                             </Box>

--- a/frontend/src/components/QuestionAndAnswer/QuestionAndAnswerFormWithApi.tsx
+++ b/frontend/src/components/QuestionAndAnswer/QuestionAndAnswerFormWithApi.tsx
@@ -31,7 +31,8 @@ const QuestionAndAnswerFormWithApi = ({ question, answer, disabled, viewProgress
 
     const { setAnswer, loading, error: errorSettingAnswer } = useSetAnswerMutation()
     const [savingState, setSavingState] = useState<SavingState>(SavingState.None)
-    const [localAnswer, setLocalAnswer] = useState<Answer>(answer ?? emptyAnswer)
+    const [localAnswerText, setLocalAnswerText] = useState<string>(answer && answer.text ? answer.text : '')
+    const [localSeverity, setLocalSeverity] = useState<Severity>(answer && answer.severity ? answer.severity : Severity.Na)
 
     useEffect(() => {
         if (loading) {
@@ -47,12 +48,16 @@ const QuestionAndAnswerFormWithApi = ({ question, answer, disabled, viewProgress
 
     useEffectNotOnMount(() => {
         const timeout = setTimeout(() => {
-            setAnswer(question.id, localAnswer.severity, localAnswer.text, viewProgression)
+            setAnswer(question.id, localSeverity, localAnswerText, viewProgression)
         }, WRITE_DELAY_MS)
         return () => {
             clearTimeout(timeout)
         }
-    }, [localAnswer])
+    }, [localAnswerText])
+
+    useEffectNotOnMount(() => {
+        setAnswer(question.id, localSeverity, localAnswerText, viewProgression)
+    }, [localSeverity])
 
     if (errorSettingAnswer !== undefined) {
         return (
@@ -66,10 +71,12 @@ const QuestionAndAnswerFormWithApi = ({ question, answer, disabled, viewProgress
         <>
             <QuestionAndAnswerForm
                 question={question}
-                answer={localAnswer}
-                onAnswerChange={answerParts => {
-                    setSavingState(SavingState.Saving)
-                    setLocalAnswer(oldLocalAnswer => ({ ...oldLocalAnswer, ...answerParts }))
+                answer={{ ...(answer || emptyAnswer), text: localAnswerText, severity: localSeverity }}
+                onAnswerTextChange={(text: string) => {
+                    setLocalAnswerText(text)
+                }}
+                onSeverityChange={(severity: Severity) => {
+                    setLocalSeverity(severity)
                 }}
                 disabled={disabled}
                 savingState={savingState}


### PR DESCRIPTION
Problem: In the main question form, when saving (only) severity on an answer and then quickly changing barrier or progression, the severity is often not saved.

Solution: The problem was that we have a delay before saving that is used when writing an answer text, so that we don't fire a graphQL mutation for every letter written. Since severity and text are both attributes on an Answer, the delay automatically applied for severity as well. I am now saving these to values in different variables so that the delay only applies to the text and not severity.