### PR TITLE
Add list of questions to each barrier in admin page

### DIFF
--- a/backend/api/GQL/Query.cs
+++ b/backend/api/GQL/Query.cs
@@ -13,6 +13,7 @@ namespace api.GQL
         private readonly EvaluationService _evaluationService;
         private readonly ParticipantService _participantService;
         private readonly QuestionService _questionService;
+        private readonly QuestionTemplateService _questionTemplateService;
         private readonly AnswerService _answerService;
         private readonly ActionService _actionService;
         private readonly NoteService _noteService;
@@ -24,6 +25,7 @@ namespace api.GQL
             EvaluationService evaluationService,
             ParticipantService participantService,
             QuestionService questionService,
+            QuestionTemplateService questionTemplateService,
             AnswerService answerService,
             ActionService actionService,
             NoteService noteService,
@@ -35,6 +37,7 @@ namespace api.GQL
             _evaluationService = evaluationService;
             _participantService = participantService;
             _questionService = questionService;
+            _questionTemplateService = questionTemplateService;
             _answerService = answerService;
             _actionService = actionService;
             _noteService = noteService;
@@ -83,6 +86,13 @@ namespace api.GQL
         public IQueryable<Question> GetQuestions()
         {
             return _questionService.GetAll();
+        }
+
+        [UseProjection]
+        [UseFiltering]
+        public IQueryable<QuestionTemplate> GetQuestionTemplates()
+        {
+            return _questionTemplateService.GetAll();
         }
 
         [UseProjection]

--- a/backend/tests/GQL/Query.cs
+++ b/backend/tests/GQL/Query.cs
@@ -19,6 +19,7 @@ namespace tests
                 new EvaluationService(_context),
                 new ParticipantService(_context),
                 new QuestionService(_context),
+                new QuestionTemplateService(_context),
                 new AnswerService(_context),
                 new ActionService(_context),
                 new NoteService(_context),

--- a/frontend/src/api/fragments.ts
+++ b/frontend/src/api/fragments.ts
@@ -57,6 +57,17 @@ export const QUESTION_FIELDS_FRAGMENT = gql`
         __typename
     }
 `
+export const QUESTIONTEMPLATE_FIELDS_FRAGMENT = gql`
+    fragment QuestionTemplateFields on QuestionTemplate {
+        id
+        text
+        supportNotes
+        barrier
+        order
+        organization
+        __typename
+    }
+`
 
 export const QUESTION_ANSWERS_FRAGMENT = gql`
     fragment QuestionAnswers on Question {

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -211,6 +211,7 @@ export type GraphQuery = {
   evaluations?: Maybe<Array<Maybe<Evaluation>>>;
   participants?: Maybe<Array<Maybe<Participant>>>;
   questions?: Maybe<Array<Maybe<Question>>>;
+  questionTemplates?: Maybe<Array<Maybe<QuestionTemplate>>>;
   answers?: Maybe<Array<Maybe<Answer>>>;
   actions?: Maybe<Array<Maybe<Action>>>;
   notes?: Maybe<Array<Maybe<Note>>>;
@@ -240,6 +241,11 @@ export type GraphQueryParticipantsArgs = {
 
 export type GraphQueryQuestionsArgs = {
   where?: Maybe<QuestionFilterInput>;
+};
+
+
+export type GraphQueryQuestionTemplatesArgs = {
+  where?: Maybe<QuestionTemplateFilterInput>;
 };
 
 

--- a/frontend/src/views/Admin/AdminQuestionItem.tsx
+++ b/frontend/src/views/Admin/AdminQuestionItem.tsx
@@ -1,0 +1,43 @@
+import { Chip, EditIcon, MoreIcon } from '@equinor/fusion-components'
+import { Divider, Typography } from '@equinor/eds-core-react'
+import { tokens } from '@equinor/eds-tokens'
+import { Box } from '@material-ui/core'
+
+import { QuestionTemplate } from '../../api/models'
+import { organizationToString } from '../../utils/EnumToString'
+
+interface Props {
+    question: QuestionTemplate
+}
+
+const AdminQuestionItem = ({ question }: Props) => {
+    return (
+        <div key={question.id} id={`question-${question.order}`}>
+            <Divider />
+            <Box display="flex" flexDirection="row">
+                <Box display="flex" flexGrow={1} mb={3} mr={22}>
+                    <Box ml={2} mr={1}>
+                        <Typography variant="h4">{question.order}.</Typography>
+                    </Box>
+                    <Box>
+                        <Typography variant="h4">{question.text}</Typography>
+                        <div style={{ marginBottom: 10 }}>
+                            <Chip primary title={organizationToString(question.organization)} />
+                        </div>
+                        {question.supportNotes.split('\n').map(supportNotePart => {
+                            return <Typography key={question.id + supportNotePart}>{supportNotePart}</Typography>
+                        })}
+                    </Box>
+                </Box>
+                <Box mr={2}>
+                    <EditIcon cursor="pointer" color={tokens.colors.interactive.primary__resting.rgba} />
+                </Box>
+                <Box>
+                    <MoreIcon cursor="pointer" color={tokens.colors.interactive.primary__resting.rgba} />
+                </Box>
+            </Box>
+        </div>
+    )
+}
+
+export default AdminQuestionItem

--- a/frontend/src/views/Admin/AdminView.tsx
+++ b/frontend/src/views/Admin/AdminView.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
+import { MoreIcon, AddIcon } from '@equinor/fusion-components'
 import { Divider, Typography } from '@equinor/eds-core-react'
+import { tokens } from '@equinor/eds-tokens'
 import { Box } from '@material-ui/core'
+
 import BarrierSidebar from './BarrierSidebar'
 import { Barrier } from '../../api/models'
+import QuestionListWithApi from './QuestionListWithApi'
+import { barrierToString } from '../../utils/EnumToString'
 
 interface Props {}
 
@@ -24,7 +29,27 @@ const AdminView = ({}: Props) => {
                 <Typography variant="h2">Project configuration: Questionnaire</Typography>
             </Box>
             <Divider />
-            <BarrierSidebar barrier={selectedBarrier} onBarrierSelected={onBarrierSelected} />
+            <Box display="flex" height={1}>
+                <Box>
+                    <BarrierSidebar barrier={selectedBarrier} onBarrierSelected={onBarrierSelected} />
+                </Box>
+                <Box p="20px" width="1">
+                    <Box display="flex" flexDirection="row">
+                        <Box flexGrow={1} m={1}>
+                            <Typography variant="h3" ref={headerRef}>
+                                {barrierToString(selectedBarrier)}
+                            </Typography>
+                        </Box>
+                        <Box mr={2} mt={2.5}>
+                            <AddIcon cursor="pointer" color={tokens.colors.interactive.primary__resting.rgba} />
+                        </Box>
+                        <Box mt={2.5}>
+                            <MoreIcon cursor="pointer" color={tokens.colors.interactive.primary__resting.rgba} />
+                        </Box>
+                    </Box>
+                    <QuestionListWithApi barrier={selectedBarrier} />
+                </Box>
+            </Box>
         </>
     )
 }

--- a/frontend/src/views/Admin/BarrierQuestionList.tsx
+++ b/frontend/src/views/Admin/BarrierQuestionList.tsx
@@ -1,0 +1,20 @@
+import { QuestionTemplate } from '../../api/models'
+import AdminQuestionItem from './AdminQuestionItem'
+
+interface Props {
+    barrierQuestions: QuestionTemplate[]
+}
+
+const BarrierQuestionList = ({ barrierQuestions }: Props) => {
+    const orderedQuestions = barrierQuestions.sort((q1, q2) => q1.order - q2.order)
+
+    return (
+        <div>
+            {orderedQuestions.map(q => {
+                return <AdminQuestionItem question={q} />
+            })}
+        </div>
+    )
+}
+
+export default BarrierQuestionList

--- a/frontend/src/views/Admin/QuestionListWithApi.tsx
+++ b/frontend/src/views/Admin/QuestionListWithApi.tsx
@@ -1,0 +1,68 @@
+import { ApolloError, gql, useQuery } from '@apollo/client'
+import { TextArea } from '@equinor/fusion-components'
+import { apiErrorMessage } from '../../api/error'
+
+import { QUESTIONTEMPLATE_FIELDS_FRAGMENT } from '../../api/fragments'
+import { Barrier, QuestionTemplate, Status } from '../../api/models'
+import BarrierQuestionList from './BarrierQuestionList'
+
+interface Props {
+    barrier: Barrier
+}
+
+const QuestionListWithApi = ({ barrier }: Props) => {
+    const { questions, loading, error } = useQuestionTemplatesQuery()
+
+    if (loading) {
+        return <>Loading...</>
+    }
+
+    if (error !== undefined) {
+        return (
+            <div>
+                <TextArea value={apiErrorMessage('Could not load questions')} onChange={() => {}} />
+            </div>
+        )
+    }
+
+    if (questions === undefined) {
+        return (
+            <div>
+                <TextArea value={apiErrorMessage('Questions are undefined')} onChange={() => {}} />
+            </div>
+        )
+    }
+
+    const barrierQuestions = questions.filter(q => q.barrier === barrier)
+
+    return (
+        <BarrierQuestionList barrierQuestions={barrierQuestions} />
+    )
+}
+
+export default QuestionListWithApi
+
+interface QuestionTemplatesQueryProps {
+    loading: boolean
+    questions: QuestionTemplate[] | undefined
+    error: ApolloError | undefined
+}
+
+const useQuestionTemplatesQuery = (): QuestionTemplatesQueryProps => {
+    const GET_QUESTIONTEMPLATES = gql`
+        query { 
+            questionTemplates (where: {status: {eq: ${Status.Active}} }) {
+                ...QuestionTemplateFields
+            }
+        }
+        ${QUESTIONTEMPLATE_FIELDS_FRAGMENT}
+    `
+
+    const { loading, data, error } = useQuery<{ questionTemplates: QuestionTemplate[] }>(GET_QUESTIONTEMPLATES)
+
+    return {
+        loading,
+        questions: data?.questionTemplates,
+        error,
+    }
+}


### PR DESCRIPTION
With this PR, the admin view now looks like this
![Skjermbilde 2021-09-14 kl  09 14 47 (2)](https://user-images.githubusercontent.com/37103233/133212520-8c5c59c3-8b72-4181-8c0c-fac21baff042.png)

In addition to the changes in the frontend, it is now possible to query for `QuestionTemplate`.