### PR TITLE
Prepare backend for admin module

### DIFF
--- a/backend/api/Context/BmtDbContext.cs
+++ b/backend/api/Context/BmtDbContext.cs
@@ -15,6 +15,7 @@ namespace api.Context
         public DbSet<Note> Notes { get; set; }
         public DbSet<ClosingRemark> ClosingRemarks { get; set; }
         public DbSet<QuestionTemplate> QuestionTemplates { get; set; }
+        public DbSet<ProjectCategory> ProjectCategories { get; set; }
 
         public BmtDbContext(DbContextOptions<BmtDbContext> options)
         : base(options)

--- a/backend/api/Context/InitContent.cs
+++ b/backend/api/Context/InitContent.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
 
 using api.Models;
 using api.Utils;
@@ -12,6 +13,7 @@ namespace api.Context
     public static class InitContent
     {
         public static readonly List<QuestionTemplate> QuestionTemplates = GetQuestionTemplates();
+        public static readonly List<ProjectCategory> ProjectCategories = GetProjectCategories();
         public static readonly List<Project> Projects = GetProjects();
         public static readonly List<Evaluation> Evaluations = GetEvaluations();
         public static readonly List<Participant> Participants = GetParticipants();
@@ -36,6 +38,7 @@ namespace api.Context
                 q.CreateDate = DateTimeOffset.UtcNow;
                 q.Status = Status.Active;
                 q.Order = order;
+
                 order += 1;
             }
             return questions;
@@ -251,6 +254,21 @@ namespace api.Context
             return projects;
         }
 
+        private static List<ProjectCategory> GetProjectCategories()
+        {
+            var category1 = new ProjectCategory
+            {
+                Name = "CircleField"
+            };
+
+            var category2 = new ProjectCategory
+            {
+                Name = "SquareField"
+            };
+
+            return new List<ProjectCategory> { category1, category2 };
+        }
+
         public static void PopulateDb(BmtDbContext context)
         {
             if (context == null)
@@ -259,6 +277,7 @@ namespace api.Context
             }
 
             context.AddRange(Projects);
+            context.AddRange(ProjectCategories);
             context.AddRange(QuestionTemplates);
             context.AddRange(Evaluations);
             context.AddRange(Participants);
@@ -268,6 +287,17 @@ namespace api.Context
             context.AddRange(Notes);
             context.AddRange(ClosingRemarks);
 
+            context.SaveChanges();
+
+            var templates = context.QuestionTemplates.Include(x => x.ProjectCategories);
+            var categories = context.ProjectCategories;
+            foreach (var template in templates)
+            {
+                foreach(var category in categories)
+                {
+                    template.ProjectCategories.Add(category);
+                }
+            }
             context.SaveChanges();
         }
     }

--- a/backend/api/Context/InitContent.cs
+++ b/backend/api/Context/InitContent.cs
@@ -11,8 +11,8 @@ namespace api.Context
 {
     public static class InitContent
     {
-        public static readonly List<Project> Projects = GetProjects();
         public static readonly List<QuestionTemplate> QuestionTemplates = GetQuestionTemplates();
+        public static readonly List<Project> Projects = GetProjects();
         public static readonly List<Evaluation> Evaluations = GetEvaluations();
         public static readonly List<Participant> Participants = GetParticipants();
         public static readonly List<Question> Questions = GetQuestions();

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -298,6 +298,22 @@ namespace api.GQL
             }
         }
 
+        public QuestionTemplate AddToProjectCategory(
+            string questionTemplateId,
+            string projectCategoryId
+        )
+        {
+            return _questionTemplateService.AddToProjectCategory(questionTemplateId, projectCategoryId);
+        }
+
+        public QuestionTemplate RemoveFromProjectCategory(
+            string questionTemplateId,
+            string projectCategoryId
+        )
+        {
+            return _questionTemplateService.RemoveFromProjectCategory(questionTemplateId, projectCategoryId);
+        }
+
         /* Helpers */
         private Participant CurrentUser(Evaluation evaluation)
         {

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -24,6 +24,7 @@ namespace api.GQL
 
         /* Admin Services */
         private readonly QuestionTemplateService _questionTemplateService;
+        private readonly ProjectCategoryService _projectCategoryService;
 
         /* Other Services */
         private readonly IAuthService _authService;
@@ -39,6 +40,7 @@ namespace api.GQL
             NoteService noteService,
             ClosingRemarkService closingRemarkService,
             QuestionTemplateService questionTemplateService,
+            ProjectCategoryService projectCategoryService,
             IAuthService authService,
             ILogger<Mutation> logger
         )
@@ -52,6 +54,7 @@ namespace api.GQL
             _noteService = noteService;
             _closingRemarkService = closingRemarkService;
             _questionTemplateService = questionTemplateService;
+            _projectCategoryService = projectCategoryService;
             _authService = authService;
             _logger = logger;
         }
@@ -255,6 +258,11 @@ namespace api.GQL
          * There are no role based restictions to these mutations as the
          * concept "Role" only exists withing an Evaluation.
          */
+        public ProjectCategory CreateProjectCategory(string name)
+        {
+            return _projectCategoryService.Create(name);
+        }
+
         public QuestionTemplate CreateQuestionTemplate(Barrier barrier, Organization organization, string text, string supportNotes)
         {
             return _questionTemplateService.Create(barrier, organization, text, supportNotes);

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -60,19 +60,35 @@ namespace api.GQL
         }
 
         /* Primary mutations - manupulating specific Evaluations */
-        public Evaluation CreateEvaluation(string name,
-                                           string projectId,
-                                           string previousEvaluationId)
+        public Evaluation CreateEvaluation(
+            string name,
+            string projectId,
+            string previousEvaluationId,
+            string projectCategoryId
+        )
         {
-            string azureUniqueId = _authService.GetOID();
-            Project project = _projectService.GetProject(projectId);
-            Evaluation evaluation = _evaluationService.Create(
-                name, project, previousEvaluationId
-            );
-            _participantService.Create(azureUniqueId, evaluation, Organization.All, Role.Facilitator);
+            var azureUniqueId = _authService.GetOID();
 
-            _questionService.CreateBulk(_questionTemplateService.ActiveQuestions(), evaluation);
-            _logger.LogInformation($"Evaluation with id: {evaluation.Id} was created by azureId: {azureUniqueId}");
+            var project = _projectService.GetProject(projectId);
+            var evaluation = _evaluationService.Create(
+                name:                 name,
+                project:              project,
+                previousEvaluationId: previousEvaluationId
+            );
+
+            _participantService.Create(
+                azureUniqueId: azureUniqueId,
+                evaluation:    evaluation,
+                organization:  Organization.All,
+                role:          Role.Facilitator
+            );
+
+            var projectCategory = _projectCategoryService.Get(projectCategoryId);
+            var questions = _questionTemplateService.ActiveQuestions(projectCategory);
+            _questionService.CreateBulk(questions, evaluation);
+
+            var log = $"Evaluation with id: {evaluation.Id} was created by azureId: {azureUniqueId}";
+            _logger.LogInformation(log);
             return evaluation;
         }
 

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -12,15 +12,20 @@ namespace api.GQL
 {
     public class Mutation
     {
+        /* Primary Services*/
         private readonly ProjectService _projectService;
         private readonly EvaluationService _evaluationService;
         private readonly ParticipantService _participantService;
         private readonly QuestionService _questionService;
         private readonly AnswerService _answerService;
-        private readonly QuestionTemplateService _questionTemplateService;
         private readonly ActionService _actionService;
         private readonly NoteService _noteService;
         private readonly ClosingRemarkService _closingRemarkService;
+
+        /* Admin Services */
+        private readonly QuestionTemplateService _questionTemplateService;
+
+        /* Other Services */
         private readonly IAuthService _authService;
         private readonly ILogger _logger;
 
@@ -30,10 +35,10 @@ namespace api.GQL
             ParticipantService participantService,
             QuestionService questionService,
             AnswerService answerService,
-            QuestionTemplateService questionTemplateService,
             ActionService actionService,
             NoteService noteService,
             ClosingRemarkService closingRemarkService,
+            QuestionTemplateService questionTemplateService,
             IAuthService authService,
             ILogger<Mutation> logger
         )
@@ -43,14 +48,15 @@ namespace api.GQL
             _participantService = participantService;
             _questionService = questionService;
             _answerService = answerService;
-            _questionTemplateService = questionTemplateService;
             _actionService = actionService;
             _noteService = noteService;
             _closingRemarkService = closingRemarkService;
+            _questionTemplateService = questionTemplateService;
             _authService = authService;
             _logger = logger;
         }
 
+        /* Primary mutations - manupulating specific Evaluations */
         public Evaluation CreateEvaluation(string name,
                                            string projectId,
                                            string previousEvaluationId)
@@ -154,42 +160,6 @@ namespace api.GQL
             return _participantService.Remove(participantId);
         }
 
-        public QuestionTemplate CreateQuestionTemplate(Barrier barrier, Organization organization, string text, string supportNotes)
-        {
-            return _questionTemplateService.Create(barrier, organization, text, supportNotes);
-        }
-
-        public QuestionTemplate EditQuestionTemplate(
-            string questionTemplateId,
-            Barrier barrier,
-            Organization organization,
-            string text,
-            string supportNotes,
-            Status status
-        )
-        {
-            QuestionTemplate questionTemplate = _questionTemplateService.GetQuestionTemplate(questionTemplateId);
-            return _questionTemplateService.Edit(questionTemplate, barrier, organization, text, supportNotes, status);
-        }
-
-        public QuestionTemplate ReorderQuestionTemplate(
-            string questionTemplateId,
-            string newNextQuestionTemplateId
-        )
-        {
-            QuestionTemplate questionTemplate = _questionTemplateService.GetQuestionTemplate(questionTemplateId);
-            if (string.IsNullOrEmpty(newNextQuestionTemplateId))
-            {
-                return _questionTemplateService.ReorderQuestionTemplate(questionTemplate);
-            }
-            else
-            {
-                QuestionTemplate newNextQuestionTemplate = _questionTemplateService.GetQuestionTemplate(newNextQuestionTemplateId);
-                return _questionTemplateService.ReorderQuestionTemplate(questionTemplate, newNextQuestionTemplate);
-            }
-        }
-
-
         public Answer SetAnswer(string questionId, Severity severity, string text, Progression progression)
         {
             IQueryable<Question> queryableQuestion = _questionService.GetQuestion(questionId);
@@ -280,6 +250,47 @@ namespace api.GQL
             return _closingRemarkService.Create(CurrentUser(evaluation), text, action);
         }
 
+        /* Admin mutations
+         *
+         * There are no role based restictions to these mutations as the
+         * concept "Role" only exists withing an Evaluation.
+         */
+        public QuestionTemplate CreateQuestionTemplate(Barrier barrier, Organization organization, string text, string supportNotes)
+        {
+            return _questionTemplateService.Create(barrier, organization, text, supportNotes);
+        }
+
+        public QuestionTemplate EditQuestionTemplate(
+            string questionTemplateId,
+            Barrier barrier,
+            Organization organization,
+            string text,
+            string supportNotes,
+            Status status
+        )
+        {
+            QuestionTemplate questionTemplate = _questionTemplateService.GetQuestionTemplate(questionTemplateId);
+            return _questionTemplateService.Edit(questionTemplate, barrier, organization, text, supportNotes, status);
+        }
+
+        public QuestionTemplate ReorderQuestionTemplate(
+            string questionTemplateId,
+            string newNextQuestionTemplateId
+        )
+        {
+            QuestionTemplate questionTemplate = _questionTemplateService.GetQuestionTemplate(questionTemplateId);
+            if (string.IsNullOrEmpty(newNextQuestionTemplateId))
+            {
+                return _questionTemplateService.ReorderQuestionTemplate(questionTemplate);
+            }
+            else
+            {
+                QuestionTemplate newNextQuestionTemplate = _questionTemplateService.GetQuestionTemplate(newNextQuestionTemplateId);
+                return _questionTemplateService.ReorderQuestionTemplate(questionTemplate, newNextQuestionTemplate);
+            }
+        }
+
+        /* Helpers */
         private Participant CurrentUser(Evaluation evaluation)
         {
             string azureUniqueId = _authService.GetOID();

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -279,6 +279,12 @@ namespace api.GQL
             return _projectCategoryService.Create(name);
         }
 
+        public ProjectCategory CopyProjectCategory(string newName, string projectCategoryId)
+        {
+            var other = _projectCategoryService.Get(projectCategoryId);
+            return _projectCategoryService.CopyFrom(newName, other);
+        }
+
         public QuestionTemplate CreateQuestionTemplate(Barrier barrier, Organization organization, string text, string supportNotes)
         {
             return _questionTemplateService.Create(barrier, organization, text, supportNotes);

--- a/backend/api/GQL/Query.cs
+++ b/backend/api/GQL/Query.cs
@@ -18,6 +18,7 @@ namespace api.GQL
         private readonly ActionService _actionService;
         private readonly NoteService _noteService;
         private readonly ClosingRemarkService _closingRemarkService;
+        private readonly ProjectCategoryService _projectCategoryService;
         private readonly ILogger _logger;
 
         public GraphQuery(
@@ -30,6 +31,7 @@ namespace api.GQL
             ActionService actionService,
             NoteService noteService,
             ClosingRemarkService closingRemarkService,
+            ProjectCategoryService projectCategoryService,
             ILogger<GraphQuery> logger
         )
         {
@@ -42,6 +44,7 @@ namespace api.GQL
             _actionService = actionService;
             _noteService = noteService;
             _closingRemarkService = closingRemarkService;
+            _projectCategoryService = projectCategoryService;
             _logger = logger;
         }
 
@@ -121,6 +124,13 @@ namespace api.GQL
         public IQueryable<ClosingRemark> GetClosingRemarks()
         {
             return _closingRemarkService.GetAll();
+        }
+
+        [UseProjection]
+        [UseFiltering]
+        public IQueryable<ProjectCategory> GetProjectCategory()
+        {
+            return _projectCategoryService.GetAll();
         }
     }
 }

--- a/backend/api/Migrations/20210915135241_AddProjectCategory.Designer.cs
+++ b/backend/api/Migrations/20210915135241_AddProjectCategory.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Context;
 
 namespace api.Migrations
 {
     [DbContext(typeof(BmtDbContext))]
-    partial class BmtDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210915135241_AddProjectCategory")]
+    partial class AddProjectCategory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/api/Migrations/20210915135241_AddProjectCategory.cs
+++ b/backend/api/Migrations/20210915135241_AddProjectCategory.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace api.Migrations
+{
+    public partial class AddProjectCategory : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProjectCategories",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectCategories", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProjectCategoryQuestionTemplate",
+                columns: table => new
+                {
+                    ProjectCategoriesId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    QuestionTemplatesId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectCategoryQuestionTemplate", x => new { x.ProjectCategoriesId, x.QuestionTemplatesId });
+                    table.ForeignKey(
+                        name: "FK_ProjectCategoryQuestionTemplate_ProjectCategories_ProjectCategoriesId",
+                        column: x => x.ProjectCategoriesId,
+                        principalTable: "ProjectCategories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ProjectCategoryQuestionTemplate_QuestionTemplates_QuestionTemplatesId",
+                        column: x => x.QuestionTemplatesId,
+                        principalTable: "QuestionTemplates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectCategoryQuestionTemplate_QuestionTemplatesId",
+                table: "ProjectCategoryQuestionTemplate",
+                column: "QuestionTemplatesId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProjectCategoryQuestionTemplate");
+
+            migrationBuilder.DropTable(
+                name: "ProjectCategories");
+        }
+    }
+}

--- a/backend/api/Models/Models.cs
+++ b/backend/api/Models/Models.cs
@@ -98,6 +98,20 @@ namespace api.Models
         public virtual QuestionTemplate QuestionTemplate { get; set; }
     }
 
+    public class ProjectCategory
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [Required]
+        public string Id { get; set; }
+
+        [Required]
+        public string Name { get; set; }
+
+        [Required]
+        public ICollection<QuestionTemplate> QuestionTemplates { get; set; }
+    }
+
     public class QuestionTemplate
     {
         [Key]
@@ -121,6 +135,8 @@ namespace api.Models
         [Required]
         public virtual ICollection<Question> Questions { get; private set; }
         public QuestionTemplate previous { get; set; }
+        [Required]
+        public ICollection<ProjectCategory> ProjectCategories { get; set; }
     }
 
     public class Answer

--- a/backend/api/Services/ProjectCategoryService.cs
+++ b/backend/api/Services/ProjectCategoryService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Collections.Generic;
 
 using api.Context;
 using api.Models;
@@ -7,12 +8,24 @@ using api.Models;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.EntityFrameworkCore;
 
 namespace api.Services
 {
     public class ProjectCategoryService
     {
         private readonly BmtDbContext _context;
+
+        private ProjectCategory _Create(string name)
+        {
+            var newProjectCategory = new ProjectCategory
+            {
+                Name = name,
+                QuestionTemplates = new List<QuestionTemplate>()
+            };
+
+            return newProjectCategory;
+        }
 
         public ProjectCategoryService(BmtDbContext context)
         {
@@ -21,11 +34,20 @@ namespace api.Services
 
         public ProjectCategory Create(string name)
         {
+            var newProjectCategory = _Create(name);
+            _context.ProjectCategories.Add(newProjectCategory);
+            _context.SaveChanges();
+            return newProjectCategory;
+        }
 
-            ProjectCategory newProjectCategory = new ProjectCategory
+        public ProjectCategory CopyFrom(string newName, ProjectCategory other)
+        {
+            var newProjectCategory = _Create(newName);
+
+            foreach(var template in other.QuestionTemplates)
             {
-                Name = name,
-            };
+                newProjectCategory.QuestionTemplates.Add(template);
+            }
 
             _context.ProjectCategories.Add(newProjectCategory);
             _context.SaveChanges();

--- a/backend/api/Services/ProjectCategoryService.cs
+++ b/backend/api/Services/ProjectCategoryService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+
+using api.Context;
+using api.Models;
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace api.Services
+{
+    public class ProjectCategoryService
+    {
+        private readonly BmtDbContext _context;
+
+        public ProjectCategoryService(BmtDbContext context)
+        {
+            _context = context;
+        }
+
+        public ProjectCategory Create(string name)
+        {
+
+            ProjectCategory newProjectCategory = new ProjectCategory
+            {
+                Name = name,
+            };
+
+            _context.ProjectCategories.Add(newProjectCategory);
+            _context.SaveChanges();
+            return newProjectCategory;
+        }
+
+        public ProjectCategory Get(string id)
+        {
+            ProjectCategory category = _context.ProjectCategories.FirstOrDefault(
+                x => x.Id.Equals(id)
+            );
+
+            if (category == null)
+            {
+                string msg = $"ProjectCategory not found: {id}";
+                throw new NotFoundInDBException(msg);
+            }
+
+            return category;
+        }
+
+        public IQueryable<ProjectCategory> GetAll()
+        {
+            return _context.ProjectCategories;
+        }
+    }
+}

--- a/backend/api/Services/QuestionTemplateService.cs
+++ b/backend/api/Services/QuestionTemplateService.cs
@@ -17,11 +17,16 @@ namespace api.Services
             _context = context;
         }
 
-        public List<QuestionTemplate> ActiveQuestions()
+        public List<QuestionTemplate> ActiveQuestions(ProjectCategory projectCategory)
         {
-            List<QuestionTemplate> questions = _context.QuestionTemplates.Where(
-                template => template.Status.Equals(Status.Active)
-            ).ToList();
+            List<QuestionTemplate> questions = _context.QuestionTemplates
+                .Include(x => x.ProjectCategories)
+                .Where(template =>
+                    template.Status.Equals(Status.Active) &&
+                    template.ProjectCategories.Contains(projectCategory)
+                )
+                .ToList();
+
             return questions;
         }
 

--- a/backend/api/Services/QuestionTemplateService.cs
+++ b/backend/api/Services/QuestionTemplateService.cs
@@ -78,6 +78,7 @@ namespace api.Services
                 Status = status,
                 Order = questionTemplate.Order,
                 previous = questionTemplate,
+                ProjectCategories = questionTemplate.ProjectCategories
             };
             _context.QuestionTemplates.Add(newQuestionTemplate);
 

--- a/backend/api/Startup.cs
+++ b/backend/api/Startup.cs
@@ -110,10 +110,10 @@ namespace api
             services.AddScoped<EvaluationService>();
             services.AddScoped<QuestionService>();
             services.AddScoped<AnswerService>();
-            services.AddScoped<QuestionTemplateService>();
             services.AddScoped<ActionService>();
             services.AddScoped<NoteService>();
             services.AddScoped<ClosingRemarkService>();
+            services.AddScoped<QuestionTemplateService>();
             services.AddScoped<IAuthService, AuthService>();
 
             services.AddGraphQLServer()

--- a/backend/api/Startup.cs
+++ b/backend/api/Startup.cs
@@ -114,6 +114,7 @@ namespace api
             services.AddScoped<NoteService>();
             services.AddScoped<ClosingRemarkService>();
             services.AddScoped<QuestionTemplateService>();
+            services.AddScoped<ProjectCategoryService>();
             services.AddScoped<IAuthService, AuthService>();
 
             services.AddGraphQLServer()

--- a/backend/tests/DbContext.cs
+++ b/backend/tests/DbContext.cs
@@ -200,6 +200,7 @@ namespace tests
                 .AddScoped<NoteService>()
                 .AddScoped<ClosingRemarkService>()
                 .AddScoped<QuestionTemplateService>()
+                .AddScoped<ProjectCategoryService>()
                 .AddScoped<Mutation>()
                 .BuildServiceProvider();
             return serviceProvider;

--- a/backend/tests/DbContext.cs
+++ b/backend/tests/DbContext.cs
@@ -196,10 +196,10 @@ namespace tests
                 .AddScoped<EvaluationService>()
                 .AddScoped<QuestionService>()
                 .AddScoped<AnswerService>()
-                .AddScoped<QuestionTemplateService>()
                 .AddScoped<ActionService>()
                 .AddScoped<NoteService>()
                 .AddScoped<ClosingRemarkService>()
+                .AddScoped<QuestionTemplateService>()
                 .AddScoped<Mutation>()
                 .BuildServiceProvider();
             return serviceProvider;

--- a/backend/tests/GQL/Mutation.cs
+++ b/backend/tests/GQL/Mutation.cs
@@ -13,17 +13,21 @@ namespace tests
     [Collection("UsesDbContext")]
     public class MutationTest : DbContextTestSetup
     {
-        /* Services */
+        /* Primary Services*/
         protected readonly Mutation _mutation;
         protected readonly ProjectService _projectService;
         protected readonly EvaluationService _evaluationService;
         protected readonly ParticipantService _participantService;
         protected readonly QuestionService _questionService;
         protected readonly AnswerService _answerService;
-        protected readonly QuestionTemplateService _questionTemplateService;
         protected readonly ActionService _actionService;
         protected readonly NoteService _noteService;
         protected readonly ClosingRemarkService _closingRemarkService;
+
+        /* Admin Services */
+        protected readonly QuestionTemplateService _questionTemplateService;
+
+        /* Other Services */
         protected readonly MockAuthService _authService;
 
         /* Helpers */
@@ -37,10 +41,10 @@ namespace tests
             _participantService = new ParticipantService(_context);
             _questionService = new QuestionService(_context);
             _answerService = new AnswerService(_context);
-            _questionTemplateService = new QuestionTemplateService(_context);
             _actionService = new ActionService(_context);
             _noteService = new NoteService(_context);
             _closingRemarkService = new ClosingRemarkService(_context);
+            _questionTemplateService = new QuestionTemplateService(_context);
             _authService = new MockAuthService();
             _mutation = new Mutation(
                 _projectService,
@@ -48,10 +52,10 @@ namespace tests
                 _participantService,
                 _questionService,
                 _answerService,
-                _questionTemplateService,
                 _actionService,
                 _noteService,
                 _closingRemarkService,
+                _questionTemplateService,
                 _authService,
                 new Logger<Mutation>(factory)
             );

--- a/backend/tests/GQL/Mutation.cs
+++ b/backend/tests/GQL/Mutation.cs
@@ -26,6 +26,7 @@ namespace tests
 
         /* Admin Services */
         protected readonly QuestionTemplateService _questionTemplateService;
+        protected readonly ProjectCategoryService _projectCategoryService;
 
         /* Other Services */
         protected readonly MockAuthService _authService;
@@ -45,6 +46,7 @@ namespace tests
             _noteService = new NoteService(_context);
             _closingRemarkService = new ClosingRemarkService(_context);
             _questionTemplateService = new QuestionTemplateService(_context);
+            _projectCategoryService = new ProjectCategoryService(_context);
             _authService = new MockAuthService();
             _mutation = new Mutation(
                 _projectService,
@@ -56,6 +58,7 @@ namespace tests
                 _noteService,
                 _closingRemarkService,
                 _questionTemplateService,
+                _projectCategoryService,
                 _authService,
                 new Logger<Mutation>(factory)
             );

--- a/backend/tests/GQL/Mutation.cs
+++ b/backend/tests/GQL/Mutation.cs
@@ -71,7 +71,8 @@ namespace tests
         protected Evaluation CreateEvaluation(
             string name = null,
             string projectId = null,
-            string previousEvaluationId = null)
+            string previousEvaluationId = null,
+            string projectCategoryId = null)
         {
             if (name == null)
             {
@@ -88,10 +89,16 @@ namespace tests
                 previousEvaluationId = "";
             }
 
+            if (projectCategoryId == null)
+            {
+                projectCategoryId = _projectCategoryService.GetAll().First().Id;
+            }
+
             Evaluation evaluation =  _mutation.CreateEvaluation(
-                name: name,
-                projectId: projectId,
-                previousEvaluationId:  previousEvaluationId
+                name:                 name,
+                projectId:            projectId,
+                previousEvaluationId: previousEvaluationId,
+                projectCategoryId:    projectCategoryId
             );
 
             return evaluation;

--- a/backend/tests/GQL/Mutations/CreateEvaluation.cs
+++ b/backend/tests/GQL/Mutations/CreateEvaluation.cs
@@ -1,0 +1,38 @@
+using Xunit;
+using System;
+using System.Linq;
+
+using api.Models;
+using api.Services;
+using api.GQL;
+
+
+namespace tests
+{
+    public class CreateEvaluationMutation : MutationTest
+    {
+        /* Tests */
+        [Fact]
+        public void CreateAddsCorrectQuestions()
+        {
+            var projectCategory = _projectCategoryService
+                .GetAll()
+                .First()
+            ;
+
+            var nActiveTemplates = projectCategory.QuestionTemplates
+                .Where(x => x.Status.Equals(Status.Active))
+                .Count()
+            ;
+
+            var evaluation = _mutation.CreateEvaluation(
+                name: Randomize.String(),
+                projectId: _projectService.GetAll().First().Id,
+                previousEvaluationId: "",
+                projectCategoryId: projectCategory.Id
+            );
+
+            Assert.Equal(evaluation.Questions.Count(), nActiveTemplates);
+        }
+    }
+}

--- a/backend/tests/GQL/Query.cs
+++ b/backend/tests/GQL/Query.cs
@@ -24,6 +24,7 @@ namespace tests
                 new ActionService(_context),
                 new NoteService(_context),
                 new ClosingRemarkService(_context),
+                new ProjectCategoryService(_context),
                 new Logger<GraphQuery>(factory)
             );
         }

--- a/backend/tests/Randomize.cs
+++ b/backend/tests/Randomize.cs
@@ -45,6 +45,11 @@ namespace tests
             return RandomEnumValue<Organization>();
         }
 
+        public static Barrier Barrier()
+        {
+            return RandomEnumValue<Barrier>();
+        }
+
         public static Progression Progression()
         {
             return RandomEnumValue<Progression>();

--- a/backend/tests/Services/ProjectCategoryService.cs
+++ b/backend/tests/Services/ProjectCategoryService.cs
@@ -32,6 +32,20 @@ namespace tests
         }
 
         [Fact]
+        public void CopyFrom()
+        {
+            var service = new ProjectCategoryService(_context);
+            var nProjectCategories = service.GetAll().Count();
+            var other = service.GetAll().First();
+            var nTemplates = other.QuestionTemplates.Count();
+
+            var projectCategory = service.CopyFrom(Randomize.String(), other);
+
+            Assert.Equal(nProjectCategories + 1, service.GetAll().Count());
+            Assert.Equal(nTemplates, projectCategory.QuestionTemplates.Count());
+        }
+
+        [Fact]
         public void GetExising()
         {
             var service = new ProjectCategoryService(_context);

--- a/backend/tests/Services/ProjectCategoryService.cs
+++ b/backend/tests/Services/ProjectCategoryService.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Xunit;
+
+using api.Models;
+using api.Services;
+
+namespace tests
+{
+    [Collection("UsesDbContext")]
+    public class ProjectCategoryServiceTest  : DbContextTestSetup
+    {
+        [Fact]
+        public void GetQueryable()
+        {
+            var service = new AnswerService(_context);
+
+            Assert.True(service.GetAll().Count() > 0);
+        }
+
+        [Fact]
+        public void Create()
+        {
+            var service = new ProjectCategoryService(_context);
+
+            int nCategories = service.GetAll().Count();
+            service.Create(Randomize.String());
+
+            Assert.Equal(nCategories + 1, service.GetAll().Count());
+        }
+
+        [Fact]
+        public void GetExising()
+        {
+            var service = new ProjectCategoryService(_context);
+
+            var name = Randomize.String();
+            var exisingId = service.Create(name).Id;
+            var exists = service.Get(exisingId);
+
+            Assert.Equal(name, exists.Name);
+        }
+
+        [Fact]
+        public void GetNonExisting()
+        {
+            var service = new ProjectCategoryService(_context);
+
+            var nonExistingId = Randomize.String();
+
+            Assert.Throws<NotFoundInDBException>(
+                () => service.Get(nonExistingId)
+            );
+        }
+    }
+}
+

--- a/backend/tests/Services/QuestionTemplateService.cs
+++ b/backend/tests/Services/QuestionTemplateService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -55,17 +56,41 @@ namespace tests
         [Fact]
         public void EditQuestionTemplate()
         {
-            QuestionTemplateService questionTemplateService = new QuestionTemplateService(_context);
-            string initialText = "initial text";
-            QuestionTemplate questionTemplate = questionTemplateService.Create(Barrier.GM, Organization.All, initialText, "supportNotes");
+            var service = new QuestionTemplateService(_context);
+            var originalQT = service.Create(
+                barrier:      Randomize.Barrier(),
+                organization: Randomize.Organization(),
+                text:         Randomize.String(),
+                supportNotes: Randomize.String()
+            );
 
-            string newtext = "new text";
-            Barrier newBarrier = Barrier.PS1;
-            QuestionTemplate resultingQuestionTemplate = questionTemplateService.Edit(questionTemplate, newBarrier, Organization.Commissioning, newtext, "supportNotes", Status.Active);
+            var projectCategory  = new ProjectCategoryService(_context).GetAll().First();
+            originalQT = service.AddToProjectCategory(originalQT.Id, projectCategory.Id);
 
-            Assert.Equal(newtext, resultingQuestionTemplate.Text);
-            Assert.Equal(newBarrier, resultingQuestionTemplate.Barrier);
-            Assert.Equal(questionTemplate, resultingQuestionTemplate.previous);
+            var nTemplates = service.GetAll().Count();
+
+            var newText         = Randomize.String();
+            var newSupportNotes = Randomize.String();
+            var newOrganization = Randomize.Organization();
+            var newBarrier      = Randomize.Barrier();
+
+            var updatedQT = service.Edit(
+                questionTemplate: originalQT,
+                barrier:          newBarrier,
+                organization:     newOrganization,
+                text:             newText,
+                supportNotes:     newSupportNotes,
+                status:           Status.Active
+            );
+
+            Assert.Equal(nTemplates + 1, service.GetAll().Count());
+
+            Assert.Equal(newText,          updatedQT.Text);
+            Assert.Equal(newSupportNotes,  updatedQT.SupportNotes);
+            Assert.Equal(newBarrier,       updatedQT.Barrier);
+            Assert.Equal(newOrganization,  updatedQT.Organization);
+
+            Assert.Equal(originalQT,       updatedQT.previous);
         }
 
         [Fact]
@@ -93,6 +118,57 @@ namespace tests
             QuestionTemplate resultingQuestionTemplate = questionTemplateService.ReorderQuestionTemplate(questionTemplate);
 
             Assert.Equal(newOrder, resultingQuestionTemplate.Order);
+        }
+
+        [Fact]
+        public void AddToProjectCategory()
+        {
+            var projectCategoryService = new ProjectCategoryService(_context);
+            var projectCategory = projectCategoryService.Create(Randomize.String());
+
+            var service = new QuestionTemplateService(_context);
+            var nTemplates = service.GetAll().Count();
+            var template = service.GetAll().First();
+
+            var updatedQT = service.AddToProjectCategory(template.Id, projectCategory.Id);
+            var updatedSP = projectCategoryService.Get(projectCategory.Id);
+
+            Assert.True(updatedQT.ProjectCategories.Contains(updatedSP));
+            Assert.True(updatedSP.QuestionTemplates.Contains(updatedQT));
+
+            Assert.Equal(nTemplates,  service.GetAll().Count());
+
+            /* Adding the same QuestionTemplate should fail */
+            Assert.Throws<Exception>(() =>
+                service.AddToProjectCategory(template.Id, projectCategory.Id)
+            );
+        }
+
+        [Fact]
+        public void RemoveFromProjectCategory()
+        {
+            var projectCategoryService = new ProjectCategoryService(_context);
+            var projectCategory = projectCategoryService.Create(Randomize.String());
+
+            var service = new QuestionTemplateService(_context);
+            var template = service.GetAll().First();
+
+            service.AddToProjectCategory(template.Id, projectCategory.Id);
+
+            var nTemplates = service.GetAll().Count();
+
+            var updatedQT = service.RemoveFromProjectCategory(template.Id, projectCategory.Id);
+            var updatedSP = projectCategoryService.Get(projectCategory.Id);
+
+            Assert.False(updatedQT.ProjectCategories.Contains(updatedSP));
+            Assert.False(updatedSP.QuestionTemplates.Contains(updatedQT));
+
+            Assert.Equal(nTemplates,  service.GetAll().Count());
+
+            /* Removing the same QuestionTemplate should fail */
+            Assert.Throws<Exception>(() =>
+                service.RemoveFromProjectCategory(template.Id, projectCategory.Id)
+            );
         }
     }
 }

--- a/backend/tests/Services/QuestionTemplateService.cs
+++ b/backend/tests/Services/QuestionTemplateService.cs
@@ -68,6 +68,7 @@ namespace tests
             originalQT = service.AddToProjectCategory(originalQT.Id, projectCategory.Id);
 
             var nTemplates = service.GetAll().Count();
+            var nActive = service.ActiveQuestions(projectCategory).Count();
 
             var newText         = Randomize.String();
             var newSupportNotes = Randomize.String();
@@ -84,6 +85,7 @@ namespace tests
             );
 
             Assert.Equal(nTemplates + 1, service.GetAll().Count());
+            Assert.Equal(nActive, service.ActiveQuestions(projectCategory).Count());
 
             Assert.Equal(newText,          updatedQT.Text);
             Assert.Equal(newSupportNotes,  updatedQT.SupportNotes);
@@ -127,6 +129,7 @@ namespace tests
             var projectCategory = projectCategoryService.Create(Randomize.String());
 
             var service = new QuestionTemplateService(_context);
+            var nActive = service.ActiveQuestions(projectCategory).Count();
             var nTemplates = service.GetAll().Count();
             var template = service.GetAll().First();
 
@@ -136,6 +139,7 @@ namespace tests
             Assert.True(updatedQT.ProjectCategories.Contains(updatedSP));
             Assert.True(updatedSP.QuestionTemplates.Contains(updatedQT));
 
+            Assert.Equal(nActive + 1, service.ActiveQuestions(projectCategory).Count());
             Assert.Equal(nTemplates,  service.GetAll().Count());
 
             /* Adding the same QuestionTemplate should fail */
@@ -155,6 +159,7 @@ namespace tests
 
             service.AddToProjectCategory(template.Id, projectCategory.Id);
 
+            var nActive = service.ActiveQuestions(projectCategory).Count();
             var nTemplates = service.GetAll().Count();
 
             var updatedQT = service.RemoveFromProjectCategory(template.Id, projectCategory.Id);
@@ -163,6 +168,7 @@ namespace tests
             Assert.False(updatedQT.ProjectCategories.Contains(updatedSP));
             Assert.False(updatedSP.QuestionTemplates.Contains(updatedQT));
 
+            Assert.Equal(nActive - 1, service.ActiveQuestions(projectCategory).Count());
             Assert.Equal(nTemplates,  service.GetAll().Count());
 
             /* Removing the same QuestionTemplate should fail */

--- a/backend/tests/Services/QuestionTemplateService.cs
+++ b/backend/tests/Services/QuestionTemplateService.cs
@@ -21,20 +21,6 @@ namespace tests
         }
 
         [Fact]
-        public void ActiveQuestions()
-        {
-            QuestionTemplateService questionTemplateService = new QuestionTemplateService(_context);
-
-            List<QuestionTemplate> questionTemplates = questionTemplateService.ActiveQuestions();
-
-            Assert.Equal(15, questionTemplates.Count);
-            foreach (QuestionTemplate qt in questionTemplates)
-            {
-                Assert.True(qt.Status.Equals(Status.Active));
-            }
-        }
-
-        [Fact]
         public void Create()
         {
             QuestionTemplateService questionTemplateService = new QuestionTemplateService(_context);

--- a/frontend/cypress/integration/create_evaluation_spec.ts
+++ b/frontend/cypress/integration/create_evaluation_spec.ts
@@ -41,7 +41,7 @@ describe('Creating a new Evaluation', () => {
         projectPage.createEvaluationButton().click()
 
         const dialog = new ProjectPage.CreateEvaluationDialog()
-        dialog.createEvaluation(name)
+        dialog.createEvaluation(name, 'SquareField')
 
         const nominationPage = new NominationPage()
         nominationPage.evaluationTitle().should('have.text', name)
@@ -56,7 +56,7 @@ describe('Creating a new Evaluation', () => {
                 projectPage.createEvaluationButton().click()
 
                 const dialog = new ProjectPage.CreateEvaluationDialog()
-                dialog.createEvaluation(name, previous.name)
+                dialog.createEvaluation(name, 'SquareField', previous.name)
 
                 const nominationPage = new NominationPage()
                 nominationPage.evaluationTitle().should('have.text', name)

--- a/frontend/cypress/integration/sample_spec.ts
+++ b/frontend/cypress/integration/sample_spec.ts
@@ -26,6 +26,7 @@ describe('Sample tests', () => {
 
         const createEvaluationDialog = new ProjectPage.CreateEvaluationDialog()
         createEvaluationDialog.nameTextField().type(evaluationName)
+        createEvaluationDialog.projectCategoryTextField().type(`SquareField{enter}`)
         createEvaluationDialog.createButton().click()
 
         const nominationPage = new NominationPage()

--- a/frontend/cypress/support/evaluation_seed.ts
+++ b/frontend/cypress/support/evaluation_seed.ts
@@ -15,6 +15,7 @@ import {
     CREATE_NOTE,
     SET_SUMMARY,
     PROGRESS_PARTICIPANT,
+    GET_PROJECT_CATEGORY,
 } from './gql'
 
 type EvaluationSeedInput = {
@@ -194,9 +195,14 @@ const populateDB = (seed: EvaluationSeed, facilitator: Participant) => {
         })
         .then(res => {
             seed.projectId = res.body.data.project.id
-
+            return cy.gql(GET_PROJECT_CATEGORY, { variables: { name: "SquareField" } })
+        })
+        .then(res => {
+            const projectCategoryId = res.body.data.projectCategory[0].id;
             cy.log(`EvaluationSeed: Creating Evaluation by ${seed.participants[0].user}`)
-            cy.gql(ADD_EVALUATION, { variables: { name: seed.name, projectId: seed.projectId } }).then(res => {
+            cy.gql(ADD_EVALUATION, {
+                variables: { name: seed.name, projectId: seed.projectId, projectCategoryId: projectCategoryId },
+            }).then(res => {
                 const evaluation = res.body.data.createEvaluation
                 seed.evaluationId = evaluation.id
                 seed.questions = evaluation.questions

--- a/frontend/cypress/support/gql.ts
+++ b/frontend/cypress/support/gql.ts
@@ -27,9 +27,25 @@ export const GET_PROJECT = `
     }
 `
 
+export const GET_PROJECT_CATEGORY = `
+    query($name: String!) {
+        projectCategory(where: { name: { eq: $name } }) {
+            id
+        }
+    }
+`
+
 export const ADD_EVALUATION = `
-    mutation CreateEvaluation($name: String!, $projectId: String!) {
-        createEvaluation(name: $name, projectId: $projectId) {
+    mutation CreateEvaluation(
+        $name: String!,
+        $projectId: String!,
+        $projectCategoryId: String
+    ) {
+        createEvaluation(
+            name: $name,
+            projectId: $projectId,
+            projectCategoryId: $projectCategoryId
+        ) {
             id
             questions {
                 id,

--- a/frontend/cypress/support/project.ts
+++ b/frontend/cypress/support/project.ts
@@ -22,8 +22,13 @@ export default class ProjectPage {
             return cy.contains('Previous Evaluation').parent()
         }
 
-        createEvaluation = (name: string, previousEvaluation?: string) => {
+        projectCategoryTextField = () => {
+            return cy.contains('Project Category').parent()
+        }
+
+        createEvaluation = (name: string, projectCategory: string, previousEvaluation?: string) => {
             this.nameTextField().type(name)
+            this.projectCategoryTextField().type(`${projectCategory}{enter}`)
 
             if (previousEvaluation) {
                 this.previousEvaluation().click().type(`${previousEvaluation}{enter}`)

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -355,6 +355,8 @@ export type Mutation = {
   createQuestionTemplate?: Maybe<QuestionTemplate>;
   editQuestionTemplate?: Maybe<QuestionTemplate>;
   reorderQuestionTemplate?: Maybe<QuestionTemplate>;
+  addToProjectCategory?: Maybe<QuestionTemplate>;
+  removeFromProjectCategory?: Maybe<QuestionTemplate>;
 };
 
 
@@ -469,6 +471,18 @@ export type MutationEditQuestionTemplateArgs = {
 export type MutationReorderQuestionTemplateArgs = {
   questionTemplateId?: Maybe<Scalars['String']>;
   newNextQuestionTemplateId?: Maybe<Scalars['String']>;
+};
+
+
+export type MutationAddToProjectCategoryArgs = {
+  questionTemplateId?: Maybe<Scalars['String']>;
+  projectCategoryId?: Maybe<Scalars['String']>;
+};
+
+
+export type MutationRemoveFromProjectCategoryArgs = {
+  questionTemplateId?: Maybe<Scalars['String']>;
+  projectCategoryId?: Maybe<Scalars['String']>;
 };
 
 export type Note = {

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -216,6 +216,7 @@ export type GraphQuery = {
   actions?: Maybe<Array<Maybe<Action>>>;
   notes?: Maybe<Array<Maybe<Note>>>;
   closingRemarks?: Maybe<Array<Maybe<ClosingRemark>>>;
+  projectCategory?: Maybe<Array<Maybe<ProjectCategory>>>;
 };
 
 
@@ -268,6 +269,11 @@ export type GraphQueryClosingRemarksArgs = {
   where?: Maybe<ClosingRemarkFilterInput>;
 };
 
+
+export type GraphQueryProjectCategoryArgs = {
+  where?: Maybe<ProjectCategoryFilterInput>;
+};
+
 export type ListFilterInputTypeOfActionFilterInput = {
   all?: Maybe<ActionFilterInput>;
   none?: Maybe<ActionFilterInput>;
@@ -310,10 +316,24 @@ export type ListFilterInputTypeOfParticipantFilterInput = {
   any?: Maybe<Scalars['Boolean']>;
 };
 
+export type ListFilterInputTypeOfProjectCategoryFilterInput = {
+  all?: Maybe<ProjectCategoryFilterInput>;
+  none?: Maybe<ProjectCategoryFilterInput>;
+  some?: Maybe<ProjectCategoryFilterInput>;
+  any?: Maybe<Scalars['Boolean']>;
+};
+
 export type ListFilterInputTypeOfQuestionFilterInput = {
   all?: Maybe<QuestionFilterInput>;
   none?: Maybe<QuestionFilterInput>;
   some?: Maybe<QuestionFilterInput>;
+  any?: Maybe<Scalars['Boolean']>;
+};
+
+export type ListFilterInputTypeOfQuestionTemplateFilterInput = {
+  all?: Maybe<QuestionTemplateFilterInput>;
+  none?: Maybe<QuestionTemplateFilterInput>;
+  some?: Maybe<QuestionTemplateFilterInput>;
   any?: Maybe<Scalars['Boolean']>;
 };
 
@@ -325,15 +345,16 @@ export type Mutation = {
   progressParticipant?: Maybe<Participant>;
   createParticipant?: Maybe<Participant>;
   deleteParticipant?: Maybe<Participant>;
-  createQuestionTemplate?: Maybe<QuestionTemplate>;
-  editQuestionTemplate?: Maybe<QuestionTemplate>;
-  reorderQuestionTemplate?: Maybe<QuestionTemplate>;
   setAnswer?: Maybe<Answer>;
   createAction?: Maybe<Action>;
   editAction?: Maybe<Action>;
   deleteAction?: Maybe<Action>;
   createNote?: Maybe<Note>;
   createClosingRemark?: Maybe<ClosingRemark>;
+  createProjectCategory?: Maybe<ProjectCategory>;
+  createQuestionTemplate?: Maybe<QuestionTemplate>;
+  editQuestionTemplate?: Maybe<QuestionTemplate>;
+  reorderQuestionTemplate?: Maybe<QuestionTemplate>;
 };
 
 
@@ -372,30 +393,6 @@ export type MutationCreateParticipantArgs = {
 
 export type MutationDeleteParticipantArgs = {
   participantId?: Maybe<Scalars['String']>;
-};
-
-
-export type MutationCreateQuestionTemplateArgs = {
-  barrier: Barrier;
-  organization: Organization;
-  text?: Maybe<Scalars['String']>;
-  supportNotes?: Maybe<Scalars['String']>;
-};
-
-
-export type MutationEditQuestionTemplateArgs = {
-  questionTemplateId?: Maybe<Scalars['String']>;
-  barrier: Barrier;
-  organization: Organization;
-  text?: Maybe<Scalars['String']>;
-  supportNotes?: Maybe<Scalars['String']>;
-  status: Status;
-};
-
-
-export type MutationReorderQuestionTemplateArgs = {
-  questionTemplateId?: Maybe<Scalars['String']>;
-  newNextQuestionTemplateId?: Maybe<Scalars['String']>;
 };
 
 
@@ -443,6 +440,35 @@ export type MutationCreateNoteArgs = {
 export type MutationCreateClosingRemarkArgs = {
   actionId?: Maybe<Scalars['String']>;
   text?: Maybe<Scalars['String']>;
+};
+
+
+export type MutationCreateProjectCategoryArgs = {
+  name?: Maybe<Scalars['String']>;
+};
+
+
+export type MutationCreateQuestionTemplateArgs = {
+  barrier: Barrier;
+  organization: Organization;
+  text?: Maybe<Scalars['String']>;
+  supportNotes?: Maybe<Scalars['String']>;
+};
+
+
+export type MutationEditQuestionTemplateArgs = {
+  questionTemplateId?: Maybe<Scalars['String']>;
+  barrier: Barrier;
+  organization: Organization;
+  text?: Maybe<Scalars['String']>;
+  supportNotes?: Maybe<Scalars['String']>;
+  status: Status;
+};
+
+
+export type MutationReorderQuestionTemplateArgs = {
+  questionTemplateId?: Maybe<Scalars['String']>;
+  newNextQuestionTemplateId?: Maybe<Scalars['String']>;
 };
 
 export type Note = {
@@ -540,6 +566,21 @@ export type Project = {
   evaluations: Array<Maybe<Evaluation>>;
 };
 
+export type ProjectCategory = {
+  __typename?: 'ProjectCategory';
+  id: Scalars['String'];
+  name: Scalars['String'];
+  questionTemplates: Array<Maybe<QuestionTemplate>>;
+};
+
+export type ProjectCategoryFilterInput = {
+  and?: Maybe<Array<ProjectCategoryFilterInput>>;
+  or?: Maybe<Array<ProjectCategoryFilterInput>>;
+  id?: Maybe<StringOperationFilterInput>;
+  name?: Maybe<StringOperationFilterInput>;
+  questionTemplates?: Maybe<ListFilterInputTypeOfQuestionTemplateFilterInput>;
+};
+
 export type ProjectFilterInput = {
   and?: Maybe<Array<ProjectFilterInput>>;
   or?: Maybe<Array<ProjectFilterInput>>;
@@ -592,6 +633,7 @@ export type QuestionTemplate = {
   createDate: Scalars['DateTime'];
   questions: Array<Maybe<Question>>;
   previous?: Maybe<QuestionTemplate>;
+  projectCategories: Array<Maybe<ProjectCategory>>;
 };
 
 export type QuestionTemplateFilterInput = {
@@ -607,6 +649,7 @@ export type QuestionTemplateFilterInput = {
   createDate?: Maybe<ComparableDateTimeOffsetOperationFilterInput>;
   questions?: Maybe<ListFilterInputTypeOfQuestionFilterInput>;
   previous?: Maybe<QuestionTemplateFilterInput>;
+  projectCategories?: Maybe<ListFilterInputTypeOfProjectCategoryFilterInput>;
 };
 
 export enum Role {

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -364,6 +364,7 @@ export type MutationCreateEvaluationArgs = {
   name?: Maybe<Scalars['String']>;
   projectId?: Maybe<Scalars['String']>;
   previousEvaluationId?: Maybe<Scalars['String']>;
+  projectCategoryId?: Maybe<Scalars['String']>;
 };
 
 

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -352,6 +352,7 @@ export type Mutation = {
   createNote?: Maybe<Note>;
   createClosingRemark?: Maybe<ClosingRemark>;
   createProjectCategory?: Maybe<ProjectCategory>;
+  copyProjectCategory?: Maybe<ProjectCategory>;
   createQuestionTemplate?: Maybe<QuestionTemplate>;
   editQuestionTemplate?: Maybe<QuestionTemplate>;
   reorderQuestionTemplate?: Maybe<QuestionTemplate>;
@@ -448,6 +449,12 @@ export type MutationCreateClosingRemarkArgs = {
 
 export type MutationCreateProjectCategoryArgs = {
   name?: Maybe<Scalars['String']>;
+};
+
+
+export type MutationCopyProjectCategoryArgs = {
+  newName?: Maybe<Scalars['String']>;
+  projectCategoryId?: Maybe<Scalars['String']>;
 };
 
 

--- a/frontend/src/utils/QuestionAndAnswerUtils.test.ts
+++ b/frontend/src/utils/QuestionAndAnswerUtils.test.ts
@@ -99,6 +99,7 @@ describe('Test getFilledUserAnswersForProgression', () => {
             status: Status.Active,
             supportNotes: '',
             text: '',
+            projectCategories: []
         },
         supportNotes: '',
         text: '',

--- a/frontend/src/views/Project/Dashboard/CreateEvaluationButton.tsx
+++ b/frontend/src/views/Project/Dashboard/CreateEvaluationButton.tsx
@@ -19,10 +19,11 @@ const CreateEvaluationButton = ({ projectId }: CreateEvaluationButtonProps) => {
 
     const onCreateEvaluationDialogSureClick = (
         name: string,
+        projectCategoryId: string,
         previousEvaluationId?: string
     ) => {
         setShowDialog(false)
-        createEvaluation(name, projectId, previousEvaluationId)
+        createEvaluation(name, projectId, projectCategoryId, previousEvaluationId)
     }
 
     const onCreateEvaluationDialogCancelClick = () => {
@@ -82,7 +83,7 @@ const CreateEvaluationButton = ({ projectId }: CreateEvaluationButtonProps) => {
 export default CreateEvaluationButton
 
 interface CreateEvaluationMutationProps {
-    createEvaluation: (name: string, projectId: string, previousEvaluationId?: string) => void
+    createEvaluation: (name: string, projectId: string, projectCategoryId: string, previousEvaluationId?: string) => void
     loading: boolean
     evaluation: Evaluation | undefined
     error: ApolloError | undefined
@@ -94,11 +95,13 @@ const useCreateEvaluationMutation = (): CreateEvaluationMutationProps => {
             $name: String!
             $projectId: String!
             $previousEvaluationId: String
+            $projectCategoryId: String!
         ) {
             createEvaluation(
                 name: $name
                 projectId: $projectId
                 previousEvaluationId: $previousEvaluationId
+                projectCategoryId: $projectCategoryId
             ) {
                 ...EvaluationFields
             }
@@ -125,10 +128,11 @@ const useCreateEvaluationMutation = (): CreateEvaluationMutationProps => {
     const createEvaluation = (
         name: string,
         projectId: string,
+        projectCategoryId: string,
         previousEvaluationId?: string
     ) => {
         createEvaluationApolloFunc({
-            variables: { name, projectId, previousEvaluationId },
+            variables: { name, projectId, previousEvaluationId, projectCategoryId },
         })
     }
 


### PR DESCRIPTION
This PR introduces a new table "Sub Project" in our database. A sub project is essentially a set of QuestionTemplates. In the real world a subproject might be "GreenField" or "BrownField". There is many-to-many relationship between subproject and questionTemplates. I.e. a subproject contains many questionTemplates, but a questionTemplate can also used in multiple subprojects.

The subprojects are put to use in the CreateEvaluationDialog, where it's now mandatory to choose which sub project (questionnaire set) to use in the evaluation.

Additionally, several new mutations that will become useful in the new admin module is added. Authorisation mechanisms for the admin queries/mutations are not yet added

Closes #602 
Closes #604 
Closes #605
Closes #606