### PR TITLE
Add test facilitator can progress nomination stage

### DIFF
--- a/frontend/cypress/integration/evaluation_spec.ts
+++ b/frontend/cypress/integration/evaluation_spec.ts
@@ -1,0 +1,94 @@
+import { Progression, Role } from '../../src/api/models'
+import { EvaluationSeed } from '../support/evaluation_seed'
+import { evaluationName } from '../support/helpers'
+import NominationPage from '../support/nomination'
+import ProjectPage from '../support/project'
+import { getUsers, users, User } from '../support/mock/external/users'
+import * as faker from 'faker'
+import { EvaluationPage } from '../support/evaluation'
+
+describe('Evaluation management', () => {
+    const createEvaluation = (creator: User, otherUser: User, prefix: string) => {
+        let seed = new EvaluationSeed({
+            progression: faker.random.arrayElement(Object.values(Progression)),
+            users: [creator, otherUser],
+            namePrefix: prefix,
+        })
+        seed.participants[1].role = Role.Participant
+        return seed
+    }
+
+    context('Creating a new Evaluation', () => {
+        const user = users[2]
+        const evalUserIsFacilitator = createEvaluation(user, users[0], 'user is Facilitator')
+        const evalUserIsParticipant = createEvaluation(users[0], user, 'user is Participant')
+        const evalUserIsNotInEvaluation = createEvaluation(users[0], users[1], 'user is not in evaluation')
+        const previousEvaluations = [evalUserIsFacilitator, evalUserIsParticipant, evalUserIsNotInEvaluation]
+
+        before(() => {
+            evalUserIsFacilitator.plant()
+            evalUserIsParticipant.plant()
+            evalUserIsNotInEvaluation.plant()
+        })
+
+        beforeEach(() => {
+            cy.visitProject(user)
+        })
+
+        it('Without setting a previous evaluation', () => {
+            const name = evaluationName({ prefix: 'CreatedWithoutPrevLink' })
+
+            const projectPage = new ProjectPage()
+            projectPage.createEvaluationButton().click()
+
+            const dialog = new ProjectPage.CreateEvaluationDialog()
+            dialog.createEvaluation(name)
+
+            const nominationPage = new NominationPage()
+            nominationPage.evaluationTitle().should('have.text', name)
+        })
+
+        previousEvaluations.forEach(previous => {
+            it(`Choosing a previous evaluation where ${previous.name}`, () => {
+                const name = evaluationName({ prefix: 'CreatedWithPrevLink' })
+
+                const projectPage = new ProjectPage()
+                projectPage.createEvaluationButton().click()
+
+                const dialog = new ProjectPage.CreateEvaluationDialog()
+                dialog.createEvaluation(name, previous.name)
+
+                const nominationPage = new NominationPage()
+                nominationPage.evaluationTitle().should('have.text', name)
+            })
+        })
+    })
+
+    context('Progressing an Evaluation', () => {
+        let seed: EvaluationSeed
+        const evaluationPage = new EvaluationPage()
+        const nominationPage = new NominationPage()
+
+        beforeEach(() => {
+            const progression = Progression.Nomination
+            seed = new EvaluationSeed({
+                progression,
+                users: getUsers(3),
+            })
+            seed.plant()
+        })
+
+        it('FACILITATOR can progress from nomination', () => {
+            const progression = Progression.Nomination
+
+            expect(seed.participants[0].role).to.equal(Role.Facilitator)
+            cy.visitEvaluation(seed.evaluationId, seed.participants[0].user)
+
+            nominationPage.finishNominationButton().click()
+            cy.get('[data-testid=yes_button]').click()
+
+            cy.contains('a', 'Complete').should('exist')
+            evaluationPage.progressionStepLink(progression).contains('Complete').should('exist')
+        })
+    })
+})


### PR DESCRIPTION
Solves #591 

- Address time to load the page by asserting `cy.contains('a', 'Complete').should('exist')` in line 90
- Replicate the structure of tests in `actions_spec.ts` and `nominations_spec.ts` (pasted below). It seemed more consistent to rename the file `create_evaluation_spec.ts` to `evaluation_spec.ts`, add coherent `describe` and `context` keys, and add this test to in this renamed file

![Screenshot 2021-09-14 at 08 28 37](https://user-images.githubusercontent.com/62240435/133254558-f89c77c9-7c94-4c08-b9bf-2f2b25e84e6d.png)
![Screenshot 2021-09-14 at 08 31 58](https://user-images.githubusercontent.com/62240435/133254607-274506b2-2b4a-43f7-8305-55731f0ff1ae.png)


Something went wrong with rebasing master, the PR is work in progress (WIP).