### PR TITLE
Add new question template

### DIFF
--- a/frontend/src/api/fragments.ts
+++ b/frontend/src/api/fragments.ts
@@ -70,16 +70,13 @@ export const QUESTIONTEMPLATE_FIELDS_FRAGMENT = gql`
     }
 `
 
-export const QUESTIONTEMPLATE_PROJECT_CATEGORY_FIELDS_FRAGMENT = gql`
-    fragment QuestionTemplateProjectCategoryFields on QuestionTemplate {
-        ...QuestionTemplateFields
+export const PROJECT_CATEGORY_FIELDS_FRAGMENT = gql`
+    fragment ProjectCategoryFields on QuestionTemplate {
         projectCategories {
             id
             name
         }
-        __typename
     }
-    ${QUESTIONTEMPLATE_FIELDS_FRAGMENT}
 `
 
 export const QUESTION_ANSWERS_FRAGMENT = gql`

--- a/frontend/src/api/fragments.ts
+++ b/frontend/src/api/fragments.ts
@@ -66,12 +66,20 @@ export const QUESTIONTEMPLATE_FIELDS_FRAGMENT = gql`
         order
         organization
         status
+        __typename
+    }
+`
+
+export const QUESTIONTEMPLATE_PROJECT_CATEGORY_FIELDS_FRAGMENT = gql`
+    fragment QuestionTemplateProjectCategoryFields on QuestionTemplate {
+        ...QuestionTemplateFields
         projectCategories {
             id
             name
         }
         __typename
     }
+    ${QUESTIONTEMPLATE_FIELDS_FRAGMENT}
 `
 
 export const QUESTION_ANSWERS_FRAGMENT = gql`

--- a/frontend/src/views/Admin/AdminQuestionItem.tsx
+++ b/frontend/src/views/Admin/AdminQuestionItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { RefObject } from 'react'
 import { Divider } from '@equinor/eds-core-react'
 import { ProjectCategory, QuestionTemplate } from '../../api/models'
 import StaticQuestionItem from './StaticQuestionItem'
@@ -15,6 +15,7 @@ interface Props {
     projectCategories: ProjectCategory[]
     isInAddCategoryMode: boolean
     setIsInAddCategoryMode: (inMode: boolean) => void
+    questionTitleRef: RefObject<HTMLElement>
 }
 
 const AdminQuestionItem = ({
@@ -25,6 +26,7 @@ const AdminQuestionItem = ({
     projectCategories,
     isInAddCategoryMode,
     setIsInAddCategoryMode,
+    questionTitleRef,
 }: Props) => {
     const [isInEditmode, setIsInEditmode] = React.useState<boolean>(false)
 
@@ -52,6 +54,7 @@ const AdminQuestionItem = ({
                     projectCategories={projectCategories}
                     isInAddCategoryMode={isInAddCategoryMode}
                     setIsInAddCategoryMode={setIsInAddCategoryMode}
+                    questionTitleRef={questionTitleRef}
                 />
             )}
         </div>

--- a/frontend/src/views/Admin/AdminView.tsx
+++ b/frontend/src/views/Admin/AdminView.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
+import { useRef, useState } from 'react'
 import { Button, Divider, Icon, Typography } from '@equinor/eds-core-react'
 import { add, more_vertical } from '@equinor/eds-icons'
-import { useRef, useState } from 'react'
 import { ApolloError, gql, useQuery } from '@apollo/client'
 import { SearchableDropdown, SearchableDropdownOption, TextArea } from '@equinor/fusion-components'
 import { Box } from '@material-ui/core'
@@ -12,6 +11,7 @@ import QuestionListWithApi from './QuestionListWithApi'
 import { barrierToString } from '../../utils/EnumToString'
 import { apiErrorMessage } from '../../api/error'
 import BarrierMenu from './BarrierMenu'
+import CreateQuestionItem from './CreateQuestionItem'
 
 interface Props {}
 
@@ -20,6 +20,7 @@ const AdminView = ({}: Props) => {
     const [selectedProjectCategory, setSelectedProjectCategory] = useState<string>('all')
     const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false)
     const [isInAddCategoryMode, setIsInAddCategoryMode] = useState<boolean>(false)
+    const [isAddingQuestion, setIsAddingQuestion] = useState<boolean>(false)
     const headerRef = useRef<HTMLElement>(null)
     const menuAnchorRef = useRef<HTMLButtonElement>(null)
 
@@ -31,6 +32,10 @@ const AdminView = ({}: Props) => {
     }
 
     const { loading: loadingProjectCategoryQuery, projectCategories, error: errorProjectCategoryQuery } = useGetAllProjectCategoriesQuery()
+
+    const createNewQuestion = () => {
+        setIsAddingQuestion(true)
+    }
 
     if (loadingProjectCategoryQuery) {
         return <>Loading...</>
@@ -95,7 +100,7 @@ const AdminView = ({}: Props) => {
                             </Typography>
                         </Box>
                         <Box mt={2.5}>
-                            <Button variant="ghost" color="primary">
+                            <Button variant="ghost" color="primary" onClick={() => createNewQuestion()}>
                                 <Icon data={add}></Icon>
                             </Button>
                         </Box>
@@ -117,6 +122,15 @@ const AdminView = ({}: Props) => {
                         setIsInAddCategoryMode={setIsInAddCategoryMode}
                         isInAddCategoryMode={isInAddCategoryMode}
                     />
+                    {isAddingQuestion && (
+                        <>
+                            <Divider />
+                            <CreateQuestionItem 
+                                setIsAddingQuestion={setIsAddingQuestion}
+                                barrier={selectedBarrier}
+                            />
+                        </>
+                    )}
                     <QuestionListWithApi
                         barrier={selectedBarrier}
                         projectCategory={selectedProjectCategory}

--- a/frontend/src/views/Admin/AdminView.tsx
+++ b/frontend/src/views/Admin/AdminView.tsx
@@ -23,7 +23,7 @@ const AdminView = ({}: Props) => {
     const [isAddingQuestion, setIsAddingQuestion] = useState<boolean>(false)
     const headerRef = useRef<HTMLElement>(null)
     const menuAnchorRef = useRef<HTMLButtonElement>(null)
-    const quesstionTitleRef = useRef<HTMLElement>(null)
+    const questionTitleRef = useRef<HTMLElement>(null)
 
     const openMenu = () => {
         setIsMenuOpen(true)
@@ -129,7 +129,7 @@ const AdminView = ({}: Props) => {
                             <CreateQuestionItem 
                                 setIsAddingQuestion={setIsAddingQuestion}
                                 barrier={selectedBarrier}
-                                questionTitleRef={quesstionTitleRef}
+                                questionTitleRef={questionTitleRef}
                             />
                         </>
                     )}
@@ -139,7 +139,7 @@ const AdminView = ({}: Props) => {
                         projectCategories={projectCategories}
                         isInAddCategoryMode={isInAddCategoryMode}
                         setIsInAddCategoryMode={setIsInAddCategoryMode}
-                        questionTitleRef={quesstionTitleRef}
+                        questionTitleRef={questionTitleRef}
                     />
                 </Box>
             </Box>

--- a/frontend/src/views/Admin/AdminView.tsx
+++ b/frontend/src/views/Admin/AdminView.tsx
@@ -23,6 +23,7 @@ const AdminView = ({}: Props) => {
     const [isAddingQuestion, setIsAddingQuestion] = useState<boolean>(false)
     const headerRef = useRef<HTMLElement>(null)
     const menuAnchorRef = useRef<HTMLButtonElement>(null)
+    const quesstionTitleRef = useRef<HTMLElement>(null)
 
     const openMenu = () => {
         setIsMenuOpen(true)
@@ -128,6 +129,7 @@ const AdminView = ({}: Props) => {
                             <CreateQuestionItem 
                                 setIsAddingQuestion={setIsAddingQuestion}
                                 barrier={selectedBarrier}
+                                questionTitleRef={quesstionTitleRef}
                             />
                         </>
                     )}
@@ -137,6 +139,7 @@ const AdminView = ({}: Props) => {
                         projectCategories={projectCategories}
                         isInAddCategoryMode={isInAddCategoryMode}
                         setIsInAddCategoryMode={setIsInAddCategoryMode}
+                        questionTitleRef={quesstionTitleRef}
                     />
                 </Box>
             </Box>

--- a/frontend/src/views/Admin/Components/CancelOrSaveQuestion.tsx
+++ b/frontend/src/views/Admin/Components/CancelOrSaveQuestion.tsx
@@ -7,10 +7,10 @@ interface Props {
     isQuestionTemplateSaving: boolean
     setIsInMode: (isInMode: boolean) => void
     onClickSave: () => void
-    textValidity: string
+    questionTitle: string
 }
 
-const CancelOrSaveQuestion = ({ isQuestionTemplateSaving, setIsInMode, onClickSave, textValidity }: Props) => {
+const CancelOrSaveQuestion = ({ isQuestionTemplateSaving, setIsInMode, onClickSave, questionTitle }: Props) => {
     return (
         <>
             {isQuestionTemplateSaving && (
@@ -27,7 +27,7 @@ const CancelOrSaveQuestion = ({ isQuestionTemplateSaving, setIsInMode, onClickSa
                 >
                     Cancel
                 </Button>
-                <Button onClick={() => onClickSave()} disabled={isQuestionTemplateSaving || textValidity === 'error'}>
+                <Button onClick={() => onClickSave()} disabled={isQuestionTemplateSaving || questionTitle.length === 0}>
                     Save
                 </Button>
             </Box>

--- a/frontend/src/views/Admin/Components/CancelOrSaveQuestion.tsx
+++ b/frontend/src/views/Admin/Components/CancelOrSaveQuestion.tsx
@@ -18,7 +18,7 @@ const CancelOrSaveQuestion = ({ isQuestionTemplateSaving, setIsInMode, onClickSa
                     <SaveIndicator savingState={SavingState.Saving} />
                 </Box>
             )}
-            <Box alignSelf={'flex-end'}>
+            <Box alignSelf={'flex-end'} style={{ minWidth: '170px'}} >
                 <Button
                     variant="outlined"
                     style={{ marginRight: '20px' }}

--- a/frontend/src/views/Admin/Components/CancelOrSaveQuestion.tsx
+++ b/frontend/src/views/Admin/Components/CancelOrSaveQuestion.tsx
@@ -1,0 +1,38 @@
+import { Box } from '@material-ui/core'
+import { Button } from '@equinor/eds-core-react'
+import SaveIndicator from '../../../components/SaveIndicator'
+import { SavingState } from '../../../utils/Variables'
+
+interface Props {
+    isQuestionTemplateSaving: boolean
+    setIsInMode: (isInMode: boolean) => void
+    onClickSave: () => void
+    textValidity: string
+}
+
+const CancelOrSaveQuestion = ({ isQuestionTemplateSaving, setIsInMode, onClickSave, textValidity }: Props) => {
+    return (
+        <>
+            {isQuestionTemplateSaving && (
+                <Box alignSelf={'flex-end'} mb={1}>
+                    <SaveIndicator savingState={SavingState.Saving} />
+                </Box>
+            )}
+            <Box alignSelf={'flex-end'}>
+                <Button
+                    variant="outlined"
+                    style={{ marginRight: '20px' }}
+                    onClick={() => setIsInMode(false)}
+                    disabled={isQuestionTemplateSaving}
+                >
+                    Cancel
+                </Button>
+                <Button onClick={() => onClickSave()} disabled={isQuestionTemplateSaving || textValidity === 'error'}>
+                    Save
+                </Button>
+            </Box>
+        </>
+    )
+}
+
+export default CancelOrSaveQuestion

--- a/frontend/src/views/Admin/Components/ErrorSavingQuestion.tsx
+++ b/frontend/src/views/Admin/Components/ErrorSavingQuestion.tsx
@@ -1,0 +1,24 @@
+import { Box } from "@material-ui/core"
+import { TextArea } from '@equinor/fusion-components'
+import { ApolloError } from "@apollo/client"
+import { apiErrorMessage } from "../../../api/error"
+
+interface Props {
+    questionTemplateSaveError: ApolloError | undefined
+}
+
+const ErrorSavingQuestion = ({questionTemplateSaveError}: Props) => {
+    return (
+        <>
+            {questionTemplateSaveError && (
+                <Box mt={2} ml={4}>
+                    <Box>
+                        <TextArea value={apiErrorMessage('Not able to save')} onChange={() => {}} />
+                    </Box>
+                </Box>
+            )}
+        </>
+    )
+}
+
+export default ErrorSavingQuestion

--- a/frontend/src/views/Admin/CreateQuestionItem.tsx
+++ b/frontend/src/views/Admin/CreateQuestionItem.tsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useState } from 'react'
+import { MarkdownEditor, SearchableDropdown } from '@equinor/fusion-components'
+import { TextField } from '@equinor/eds-core-react'
+import { Box } from '@material-ui/core'
+
+import { Barrier, Organization, QuestionTemplate } from '../../api/models'
+import { ErrorIcon, TextFieldChangeEvent, Validity } from '../../components/Action/utils'
+import { ApolloError, gql, useMutation } from '@apollo/client'
+import { getOrganizationOptionsForDropdown, updateValidity } from '../helpers'
+import { useEffectNotOnMount } from '../../utils/hooks'
+import CancelOrSaveQuestion from './Components/CancelOrSaveQuestion'
+import ErrorSavingQuestion from './Components/ErrorSavingQuestion'
+import { QUESTIONTEMPLATE_FIELDS_FRAGMENT } from '../../api/fragments'
+
+interface Props {
+    setIsAddingQuestion: (isAddingQuestion: boolean) => void
+    barrier: Barrier
+}
+
+const CreateQuestionItem = ({
+    setIsAddingQuestion,
+    barrier,
+}: Props) => {
+    const [text, setText] = React.useState<string>('')
+    const [organization, setOrganization] = React.useState<Organization>(Organization.All)
+    const [supportNotes, setSupportNotes] = React.useState<string>('')
+    const [textValidity, setTextValidity] = useState<Validity>('default')
+
+    const isTextfieldValid = () => {
+        return text.length > 0
+    }
+
+    useEffectNotOnMount(() => {
+        if (!isTextfieldValid()) {
+            setTextValidity('error')
+        }
+    }, [text])
+
+    useEffect(() => {
+        updateValidity(isTextfieldValid(), textValidity, setTextValidity)
+    }, [text, textValidity])
+
+    const {
+        createQuestionTemplate,
+        loading: isCreateQuestionTemplateSaving,
+        newQuestionTemplate,
+        error: createQuestionTemplateSaveError,
+    } = useCreateQuestionTemplateMutation()
+
+    const createQuestion = () => {
+        const newQuestion: DataToCreateQuestionTemplate = {
+            barrier,
+            organization,
+            text,
+            supportNotes,
+        }
+        createQuestionTemplate(newQuestion)
+        setIsAddingQuestion(false)
+    }
+
+    return (
+        <Box display="flex" flexDirection="column">
+            <Box display="flex" flexDirection="row">
+                <Box display="flex" flexGrow={1} flexDirection={'column'}>
+                    <Box display="flex" ml={4} mr={2}>
+                        <TextField
+                            id={'title'}
+                            value={text}
+                            autoFocus={true}
+                            label="Question"
+                            onChange={(event: TextFieldChangeEvent) => {
+                                setText(event.target.value)
+                            }}
+                            variant={textValidity}
+                            helperText={textValidity === 'error' ? 'required' : ''}
+                            helperIcon={textValidity === 'error' ? ErrorIcon : <></>}
+                        />
+                    </Box>
+                    <Box ml={3} mt={3} mr={1} mb={10}>
+                        <MarkdownEditor
+                            onChange={markdown => setSupportNotes(markdown)}
+                            menuItems={['strong', 'em', 'bullet_list', 'ordered_list', 'blockquote', 'h1', 'h2', 'h3', 'paragraph']}
+                        >
+                            {supportNotes}
+                        </MarkdownEditor>
+                    </Box>
+                </Box>
+                <Box display="flex" flexDirection={'column'}>
+                    <Box flexGrow={1}>
+                        <SearchableDropdown
+                            label="Responsible discipline"
+                            options={getOrganizationOptionsForDropdown(organization)}
+                            onSelect={option => setOrganization(option.key as Organization)}
+                        />
+                    </Box>
+                    <CancelOrSaveQuestion
+                        isQuestionTemplateSaving={isCreateQuestionTemplateSaving}
+                        setIsInMode={setIsAddingQuestion}
+                        onClickSave={createQuestion}
+                        textValidity={textValidity}
+                    />
+                </Box>
+            </Box>
+            <ErrorSavingQuestion questionTemplateSaveError={createQuestionTemplateSaveError} />
+        </Box>
+    )
+}
+
+export default CreateQuestionItem
+
+export interface DataToCreateQuestionTemplate {
+    barrier: Barrier
+    organization: Organization
+    text: string
+    supportNotes: string
+}
+
+interface createQuestionTemplateMutationProps {
+    createQuestionTemplate: (data: DataToCreateQuestionTemplate) => void
+    loading: boolean
+    newQuestionTemplate: QuestionTemplate | undefined
+    error: ApolloError | undefined
+}
+
+const useCreateQuestionTemplateMutation = (): createQuestionTemplateMutationProps => {
+    const CREATE_QUESTION_TEMPLATE = gql`
+        mutation CreateQuestionTemplate($barrier: Barrier!, $organization: Organization!, $text: String!, $supportNotes: String!) {
+            createQuestionTemplate(barrier: $barrier, organization: $organization, text: $text, supportNotes: $supportNotes) {
+                ...QuestionTemplateFields
+            }
+        }
+        ${QUESTIONTEMPLATE_FIELDS_FRAGMENT}
+    `
+
+    const [createQuestionTemplateApolloFunc, { loading, data, error }] = useMutation(CREATE_QUESTION_TEMPLATE, {
+        update(cache, { data: { createQuestionTemplate } }) {
+            cache.modify({
+                fields: {
+                    questionTemplates(existingQuestionTemplates = []) {
+                        const newQuestionTemplateRef = cache.writeFragment({
+                            id: createQuestionTemplate.id,
+                            data: createQuestionTemplate,
+                            fragment: QUESTIONTEMPLATE_FIELDS_FRAGMENT,
+                        })
+                        return [...existingQuestionTemplates, newQuestionTemplateRef]
+                    },
+                },
+            })
+        },
+    })
+
+    const createQuestionTemplate = (data: DataToCreateQuestionTemplate) => {
+        createQuestionTemplateApolloFunc({
+            variables: { ...data },
+        })
+    }
+
+    return {
+        createQuestionTemplate,
+        loading,
+        newQuestionTemplate: data?.createQuestionTemplate,
+        error,
+    }
+}

--- a/frontend/src/views/Admin/CreateQuestionItem.tsx
+++ b/frontend/src/views/Admin/CreateQuestionItem.tsx
@@ -62,7 +62,7 @@ const CreateQuestionItem = ({ setIsAddingQuestion, barrier, questionTitleRef }: 
     return (
         <Box display="flex" flexDirection="column">
             <Box display="flex" flexDirection="row">
-                <Box display="flex" flexGrow={1} flexDirection={'column'}>
+                <Box display="flex" flexGrow={1} flexDirection={'column'} mt={0.75} >
                     <Box display="flex" ml={4} mr={2}>
                         <TextField
                             id={'title'}
@@ -89,7 +89,7 @@ const CreateQuestionItem = ({ setIsAddingQuestion, barrier, questionTitleRef }: 
                 <Box display="flex" flexDirection={'column'}>
                     <Box flexGrow={1}>
                         <SearchableDropdown
-                            label="Responsible discipline"
+                            label="Organization"
                             options={getOrganizationOptionsForDropdown(organization)}
                             onSelect={option => setOrganization(option.key as Organization)}
                         />

--- a/frontend/src/views/Admin/CreateQuestionItem.tsx
+++ b/frontend/src/views/Admin/CreateQuestionItem.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { RefObject, useEffect, useState } from 'react'
 import { MarkdownEditor, SearchableDropdown } from '@equinor/fusion-components'
 import { TextField } from '@equinor/eds-core-react'
 import { Box } from '@material-ui/core'
@@ -15,12 +15,10 @@ import { QUESTIONTEMPLATE_FIELDS_FRAGMENT } from '../../api/fragments'
 interface Props {
     setIsAddingQuestion: (isAddingQuestion: boolean) => void
     barrier: Barrier
+    questionTitleRef: RefObject<HTMLElement>
 }
 
-const CreateQuestionItem = ({
-    setIsAddingQuestion,
-    barrier,
-}: Props) => {
+const CreateQuestionItem = ({ setIsAddingQuestion, barrier, questionTitleRef }: Props) => {
     const [text, setText] = React.useState<string>('')
     const [organization, setOrganization] = React.useState<Organization>(Organization.All)
     const [supportNotes, setSupportNotes] = React.useState<string>('')
@@ -56,6 +54,9 @@ const CreateQuestionItem = ({
         }
         createQuestionTemplate(newQuestion)
         setIsAddingQuestion(false)
+        if (questionTitleRef !== null && questionTitleRef.current !== null) {
+            questionTitleRef.current.scrollIntoView({ behavior: 'smooth' })
+        }
     }
 
     return (

--- a/frontend/src/views/Admin/CreateQuestionItem.tsx
+++ b/frontend/src/views/Admin/CreateQuestionItem.tsx
@@ -97,7 +97,7 @@ const CreateQuestionItem = ({
                         isQuestionTemplateSaving={isCreateQuestionTemplateSaving}
                         setIsInMode={setIsAddingQuestion}
                         onClickSave={createQuestion}
-                        textValidity={textValidity}
+                        questionTitle={text}
                     />
                 </Box>
             </Box>

--- a/frontend/src/views/Admin/EditableQuestionItem.tsx
+++ b/frontend/src/views/Admin/EditableQuestionItem.tsx
@@ -102,7 +102,7 @@ const EditableQuestionItem = ({
                         isQuestionTemplateSaving={isQuestionTemplateSaving}
                         setIsInMode={setIsInEditmode}
                         onClickSave={saveQuestion}
-                        textValidity={textValidity}
+                        questionTitle={text}
                     />
                 </Box>
             </Box>

--- a/frontend/src/views/Admin/EditableQuestionItem.tsx
+++ b/frontend/src/views/Admin/EditableQuestionItem.tsx
@@ -1,17 +1,16 @@
 import React, { useEffect, useState } from 'react'
-import { MarkdownEditor, SearchableDropdown, SearchableDropdownOption, TextArea } from '@equinor/fusion-components'
-import { Button, TextField, Typography } from '@equinor/eds-core-react'
+import { MarkdownEditor, SearchableDropdown } from '@equinor/fusion-components'
+import { TextField, Typography } from '@equinor/eds-core-react'
 import { Box } from '@material-ui/core'
 
 import { Organization, QuestionTemplate } from '../../api/models'
 import { ErrorIcon, TextFieldChangeEvent, Validity } from '../../components/Action/utils'
 import { DataToEditQuestionTemplate } from './QuestionListWithApi'
-import SaveIndicator from '../../components/SaveIndicator'
-import { SavingState } from '../../utils/Variables'
 import { ApolloError } from '@apollo/client'
-import { apiErrorMessage } from '../../api/error'
-import { updateValidity } from '../helpers'
+import { getOrganizationOptionsForDropdown, updateValidity } from '../helpers'
 import { useEffectNotOnMount } from '../../utils/hooks'
+import CancelOrSaveQuestion from './Components/CancelOrSaveQuestion'
+import ErrorSavingQuestion from './Components/ErrorSavingQuestion'
 
 interface Props {
     question: QuestionTemplate
@@ -46,14 +45,6 @@ const EditableQuestionItem = ({
     useEffect(() => {
         updateValidity(isTextfieldValid(), textValidity, setTextValidity)
     }, [text, textValidity])
-
-    const organizationOptions: SearchableDropdownOption[] = Object.entries(Organization).map(([key, value]) => {
-        return {
-            title: key,
-            key: value,
-            isSelected: organization === value,
-        }
-    })
 
     const saveQuestion = () => {
         const newQuestion: DataToEditQuestionTemplate = {
@@ -103,37 +94,19 @@ const EditableQuestionItem = ({
                     <Box flexGrow={1}>
                         <SearchableDropdown
                             label="Organization"
-                            options={organizationOptions}
+                            options={getOrganizationOptionsForDropdown(organization)}
                             onSelect={option => setOrganization(option.key as Organization)}
                         />
                     </Box>
-                    {isQuestionTemplateSaving && (
-                        <Box alignSelf={'flex-end'} mb={1}>
-                            <SaveIndicator savingState={SavingState.Saving} />
-                        </Box>
-                    )}
-                    <Box alignSelf={'flex-end'} style={{ minWidth: '170px' }}>
-                        <Button
-                            variant="outlined"
-                            style={{ marginRight: '20px' }}
-                            onClick={() => setIsInEditmode(false)}
-                            disabled={isQuestionTemplateSaving}
-                        >
-                            Cancel
-                        </Button>
-                        <Button onClick={saveQuestion} disabled={isQuestionTemplateSaving || textValidity === 'error'}>
-                            Save
-                        </Button>
-                    </Box>
+                    <CancelOrSaveQuestion
+                        isQuestionTemplateSaving={isQuestionTemplateSaving}
+                        setIsInMode={setIsInEditmode}
+                        onClickSave={saveQuestion}
+                        textValidity={textValidity}
+                    />
                 </Box>
             </Box>
-            {questionTemplateSaveError && (
-                <Box mt={2} ml={4}>
-                    <Box>
-                        <TextArea value={apiErrorMessage('Not able to save')} onChange={() => {}} />
-                    </Box>
-                </Box>
-            )}
+            <ErrorSavingQuestion questionTemplateSaveError={questionTemplateSaveError} />
         </Box>
     )
 }

--- a/frontend/src/views/Admin/QuestionListWithApi.tsx
+++ b/frontend/src/views/Admin/QuestionListWithApi.tsx
@@ -2,8 +2,8 @@ import { ApolloError, gql, useMutation, useQuery } from '@apollo/client'
 import { TextArea } from '@equinor/fusion-components'
 
 import { apiErrorMessage } from '../../api/error'
-import { QUESTIONTEMPLATE_FIELDS_FRAGMENT } from '../../api/fragments'
 import { Barrier, Organization, ProjectCategory, QuestionTemplate, Status } from '../../api/models'
+import { QUESTIONTEMPLATE_PROJECT_CATEGORY_FIELDS_FRAGMENT } from '../../api/fragments'
 import { useEffectNotOnMount } from '../../utils/hooks'
 import AdminQuestionItem from './AdminQuestionItem'
 
@@ -93,10 +93,10 @@ const useQuestionTemplatesQuery = (): QuestionTemplatesQueryProps => {
     const GET_QUESTIONTEMPLATES = gql`
         query {
             questionTemplates (where: {status: {eq: ${Status.Active}} }) {
-                ...QuestionTemplateFields
+                ...QuestionTemplateProjectCategoryFields
             }
         }
-        ${QUESTIONTEMPLATE_FIELDS_FRAGMENT}
+        ${QUESTIONTEMPLATE_PROJECT_CATEGORY_FIELDS_FRAGMENT}
     `
 
     const { loading, data, error, refetch } = useQuery<{ questionTemplates: QuestionTemplate[] }>(GET_QUESTIONTEMPLATES)
@@ -143,10 +143,10 @@ const useQuestionTemplateMutation = (): QuestionTemplateMutationProps => {
                 supportNotes: $supportNotes
                 status: $status
             ) {
-                ...QuestionTemplateFields
+                ...QuestionTemplateProjectCategoryFields
             }
         }
-        ${QUESTIONTEMPLATE_FIELDS_FRAGMENT}
+        ${QUESTIONTEMPLATE_PROJECT_CATEGORY_FIELDS_FRAGMENT}
     `
 
     const [editQuestionTemplateApolloFunc, { loading, data, error }] = useMutation(EDIT_QUESTION_TEMPLATE)

--- a/frontend/src/views/Admin/QuestionListWithApi.tsx
+++ b/frontend/src/views/Admin/QuestionListWithApi.tsx
@@ -6,6 +6,7 @@ import { Barrier, Organization, ProjectCategory, QuestionTemplate, Status } from
 import { PROJECT_CATEGORY_FIELDS_FRAGMENT, QUESTIONTEMPLATE_FIELDS_FRAGMENT } from '../../api/fragments'
 import { useEffectNotOnMount } from '../../utils/hooks'
 import AdminQuestionItem from './AdminQuestionItem'
+import { RefObject } from 'react'
 
 interface Props {
     barrier: Barrier
@@ -13,9 +14,10 @@ interface Props {
     projectCategories: ProjectCategory[]
     isInAddCategoryMode: boolean
     setIsInAddCategoryMode: (inMode: boolean) => void
+    questionTitleRef: RefObject<HTMLElement>
 }
 
-const QuestionListWithApi = ({ barrier, projectCategory, projectCategories, isInAddCategoryMode, setIsInAddCategoryMode }: Props) => {
+const QuestionListWithApi = ({ barrier, projectCategory, projectCategories, isInAddCategoryMode, setIsInAddCategoryMode, questionTitleRef }: Props) => {
     const { questions, loading, error, refetch: refetchQuestionTemplates } = useQuestionTemplatesQuery()
     const {
         editQuestionTemplate,
@@ -73,6 +75,7 @@ const QuestionListWithApi = ({ barrier, projectCategory, projectCategories, isIn
                         projectCategories={projectCategories}
                         isInAddCategoryMode={isInAddCategoryMode}
                         setIsInAddCategoryMode={setIsInAddCategoryMode}
+                        questionTitleRef={questionTitleRef}
                     />
                 )
             })}

--- a/frontend/src/views/Admin/QuestionListWithApi.tsx
+++ b/frontend/src/views/Admin/QuestionListWithApi.tsx
@@ -3,7 +3,7 @@ import { TextArea } from '@equinor/fusion-components'
 
 import { apiErrorMessage } from '../../api/error'
 import { Barrier, Organization, ProjectCategory, QuestionTemplate, Status } from '../../api/models'
-import { QUESTIONTEMPLATE_PROJECT_CATEGORY_FIELDS_FRAGMENT } from '../../api/fragments'
+import { PROJECT_CATEGORY_FIELDS_FRAGMENT, QUESTIONTEMPLATE_FIELDS_FRAGMENT } from '../../api/fragments'
 import { useEffectNotOnMount } from '../../utils/hooks'
 import AdminQuestionItem from './AdminQuestionItem'
 
@@ -93,10 +93,12 @@ const useQuestionTemplatesQuery = (): QuestionTemplatesQueryProps => {
     const GET_QUESTIONTEMPLATES = gql`
         query {
             questionTemplates (where: {status: {eq: ${Status.Active}} }) {
-                ...QuestionTemplateProjectCategoryFields
+                ...QuestionTemplateFields
+                ...ProjectCategoryFields
             }
         }
-        ${QUESTIONTEMPLATE_PROJECT_CATEGORY_FIELDS_FRAGMENT}
+        ${QUESTIONTEMPLATE_FIELDS_FRAGMENT}
+        ${PROJECT_CATEGORY_FIELDS_FRAGMENT}
     `
 
     const { loading, data, error, refetch } = useQuery<{ questionTemplates: QuestionTemplate[] }>(GET_QUESTIONTEMPLATES)
@@ -143,10 +145,12 @@ const useQuestionTemplateMutation = (): QuestionTemplateMutationProps => {
                 supportNotes: $supportNotes
                 status: $status
             ) {
-                ...QuestionTemplateProjectCategoryFields
+                ...QuestionTemplateFields
+                ...ProjectCategoryFields
             }
         }
-        ${QUESTIONTEMPLATE_PROJECT_CATEGORY_FIELDS_FRAGMENT}
+        ${QUESTIONTEMPLATE_FIELDS_FRAGMENT}
+        ${PROJECT_CATEGORY_FIELDS_FRAGMENT}
     `
 
     const [editQuestionTemplateApolloFunc, { loading, data, error }] = useMutation(EDIT_QUESTION_TEMPLATE)

--- a/frontend/src/views/Admin/StaticQuestionItem.tsx
+++ b/frontend/src/views/Admin/StaticQuestionItem.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { RefObject, useRef, useState } from 'react'
 import { tokens } from '@equinor/eds-tokens'
 import { MarkdownViewer, TextArea } from '@equinor/fusion-components'
 import { Button, Chip, Icon, MultiSelect, Tooltip, Typography } from '@equinor/eds-core-react'
@@ -22,9 +22,10 @@ interface Props {
     projectCategories: ProjectCategory[]
     isInAddCategoryMode: boolean
     setIsInAddCategoryMode: (inMode: boolean) => void
+    questionTitleRef: RefObject<HTMLElement>
 }
 
-const StaticQuestionItem = ({ question, setIsInEditmode, projectCategories, isInAddCategoryMode, setIsInAddCategoryMode }: Props) => {
+const StaticQuestionItem = ({ question, setIsInEditmode, projectCategories, isInAddCategoryMode, setIsInAddCategoryMode, questionTitleRef }: Props) => {
     const [isOpen, setIsOpen] = useState<boolean>(false)
     const [savingState, setSavingState] = useState<SavingState>(SavingState.None)
     const anchorRef = useRef<HTMLButtonElement>(null)
@@ -105,7 +106,7 @@ const StaticQuestionItem = ({ question, setIsInEditmode, projectCategories, isIn
                         <Typography variant="h4">{question.order}.</Typography>
                     </Box>
                     <Box>
-                        <Typography variant="h4">{question.text}</Typography>
+                        <Typography variant="h4" ref={questionTitleRef}>{question.text}</Typography>
                         <Box display="flex" flexDirection="row" flexWrap="wrap" mb={2} mt={1} alignItems={'center'}>
                             <Box mr={1} mb={1}>
                                 <Chip style={{ backgroundColor: tokens.colors.infographic.primary__spruce_wood.rgba }}>

--- a/frontend/src/views/helpers.ts
+++ b/frontend/src/views/helpers.ts
@@ -1,4 +1,5 @@
-import { Progression, Question } from '../api/models'
+import { SearchableDropdownOption } from '@equinor/fusion-components'
+import { Organization, Progression, Question } from '../api/models'
 import { Validity } from '../components/Action/utils'
 import { SavingState } from '../utils/Variables'
 
@@ -107,4 +108,15 @@ export const deriveNewSavingState = (isLoading: boolean, currentSavingState: Sav
             return SavingState.NotSaved
         }
     }
+}
+
+export const getOrganizationOptionsForDropdown = (selectedOrganization: Organization) => {
+    const organizationOptions: SearchableDropdownOption[] = Object.entries(Organization).map(([key, value]) => {
+        return {
+            title: key,
+            key: value,
+            isSelected: selectedOrganization === value,
+        }
+    })
+    return organizationOptions
 }


### PR DESCRIPTION
The goal of this PR is to make it possible to add a new question template to a barrier. The component that is used to do this is quite similar to the component `EditableQuestionItem`, and consequently some refactoring has been done to avoid code duplication. Since a new question template does not belong to any project categories, the mutation that is used to create a question template cannot use the existing fragment for question templates, and consequently a new fragment has been made.