### PR TITLE
Facilitator (other users) can (not) view/edit content on workshop summary tab

### DIFF
--- a/frontend/cypress/integration/workshop_assessment_spec.ts
+++ b/frontend/cypress/integration/workshop_assessment_spec.ts
@@ -1,0 +1,58 @@
+import { EvaluationSeed } from '../support/testsetup/evaluation_seed'
+import { Progression, Role } from '../../src/api/models'
+import { WorkshopAssessmentTabs, WorkshopSummary } from '../page_objects/workshop_assessment'
+import { getUsers } from '../support/mock/external/users'
+import { MarkdownEditor, SaveIndicator } from '../page_objects/common'
+import { EvaluationPage } from '../page_objects/evaluation'
+import { SavingState } from '../../src/utils/Variables'
+
+describe('Workshop assessment', () => {
+    let seed: EvaluationSeed
+    const workshopAssessmentTabs = new WorkshopAssessmentTabs()
+    const workshopSummary = new WorkshopSummary()
+    const originalSummaryMessage = 'Chocolate for you!'
+    const editedSummaryMessage = 'Tulips for you! 🌷🌷🌷'
+    const progression = Progression.Workshop
+    const evaluationPage = new EvaluationPage()
+    const markdownEditor = new MarkdownEditor()
+
+    context('Workshop Summary', () => {
+        beforeEach(() => {
+            seed = new EvaluationSeed({
+                progression,
+                users: getUsers(4),
+                roles: [Role.Facilitator, Role.OrganizationLead, Role.Participant, Role.ReadOnly],
+            })
+            seed.addSummary({ summary: originalSummaryMessage, createdBy: seed.findParticipantByRole(Role.Facilitator) })
+            seed.plant()
+        })
+
+        it('FACILITATOR can edit and save notes', () => {
+            cy.visitProgression(progression, seed.evaluationId, seed.findParticipantByRole(Role.Facilitator).user)
+            workshopAssessmentTabs.workshopSummary().click()
+            markdownEditor.assertContent(originalSummaryMessage)
+            workshopSummary.assertEditorDisabler('hidden')
+            workshopSummary.body().within(() => {
+                markdownEditor.setContent(editedSummaryMessage)
+            })
+            new SaveIndicator().assertState(SavingState.Saved)
+
+            cy.testCacheAndDB(() => {
+                evaluationPage.progressionStepLink(progression).click()
+                workshopAssessmentTabs.workshopSummary().click()
+                markdownEditor.assertContent(editedSummaryMessage)
+            })
+        })
+
+        const roles = [Role.OrganizationLead, Role.Participant, Role.ReadOnly]
+
+        roles.forEach(role => {
+            it(`${role} can see Workshop Summary notes but not edit it`, () => {
+                cy.visitProgression(progression, seed.evaluationId, seed.findParticipantByRole(role).user)
+                workshopAssessmentTabs.workshopSummary().click()
+                markdownEditor.assertContent(originalSummaryMessage)
+                workshopSummary.assertEditorDisabler('visible')
+            })
+        })
+    })
+})

--- a/frontend/cypress/page_objects/action.ts
+++ b/frontend/cypress/page_objects/action.ts
@@ -1,8 +1,9 @@
-import { DropdownSelect, SideSheet } from '../page_objects/common'
+import { DropdownSelect, SideSheet, SaveIndicator } from '../page_objects/common'
 import { Action, Note } from '../support/testsetup/mocks'
 import { FUSION_DATE_LOCALE } from '../support/helpers/helpers'
 import { Priority, Question } from '../../src/api/models'
 import { barrierToString, organizationToString } from '../../src/utils/EnumToString'
+import { SavingState } from '../../src/utils/Variables'
 
 /**
  * List of actions under every question
@@ -147,7 +148,7 @@ export class EditActionDialog extends ActionDialog {
             .parent()
             .parent()
             .within(() => {
-                cy.getByDataTestid('save_indicator', 10000).should('have.text', 'Saved')
+                new SaveIndicator().assertState(SavingState.Saved)
             })
     }
 

--- a/frontend/cypress/page_objects/common.ts
+++ b/frontend/cypress/page_objects/common.ts
@@ -1,3 +1,5 @@
+import { SavingState } from '../../src/utils/Variables'
+
 /* It's not clear yet if common components won't clash with each other */
 export class ConfirmationDialog {
     self = () => {
@@ -59,5 +61,29 @@ export class DropdownSelect {
     select = (selectInput: Cypress.Chainable, text: string) => {
         selectInput.click()
         cy.get('section').contains('span', text).click()
+    }
+}
+
+export class MarkdownEditor {
+    setContent = (content: string) => {
+        cy.get('fusion-markdown-editor')
+            .shadow()
+            .within(() => {
+                cy.get('[id=editor]').replace(content)
+            })
+    }
+
+    assertContent = (content: string) => {
+        cy.contains(content, { includeShadowDom: true }).should('be.visible')
+    }
+}
+
+export class SaveIndicator {
+    assertState = (state: SavingState) => {
+        if (state === SavingState.Saved) {
+            cy.getByDataTestid('save_indicator', 10000).should('have.text', 'Saved')
+        } else {
+            throw new Error('SavingState Saving, NotSaved and None not implemented for tests.')
+        }
     }
 }

--- a/frontend/cypress/page_objects/workshop_assessment.ts
+++ b/frontend/cypress/page_objects/workshop_assessment.ts
@@ -1,0 +1,23 @@
+export class WorkshopAssessmentTabs {
+    workshopSummary = () => {
+        return cy.getByDataTestid('workshop_assessment_tablist').contains('Workshop Summary')
+    }
+}
+
+export class WorkshopSummary {
+    body = () => {
+        return cy.getByDataTestid('workshop_summary_div')
+    }
+
+    assertEditorDisabler = (boxStatus: 'hidden' | 'visible') => {
+        if (boxStatus === 'visible') {
+            this.body().within(() => {
+                cy.getByDataTestid('disabler_box_div').should('have.css', 'display', 'block')
+            })
+        } else if (boxStatus === 'hidden') {
+            this.body().within(() => {
+                cy.getByDataTestid('disabler_box_div').should('have.css', 'display', 'none')
+            })
+        }
+    }
+}

--- a/frontend/cypress/support/commands/visit.ts
+++ b/frontend/cypress/support/commands/visit.ts
@@ -1,5 +1,8 @@
 import { User } from '../mock/external/users'
 import { getFusionProjectData, findFusionProjectByID } from '../mock/external/projects'
+import { Evaluation, Progression } from '../../../src/api/models'
+import { EvaluationPage } from '../../page_objects/evaluation'
+
 function setupEnvironment() {
     cy.interceptExternal()
     cy.viewport(1800, 1000) //until we decide to test on various resolutions
@@ -66,6 +69,12 @@ Cypress.Commands.add('visitEvaluation', (evaluationId: string, user: User, fusio
     waitForEvaluationPageLoad()
 })
 
+Cypress.Commands.add('visitProgression', (progression: Progression, evaluationId: string, user: User, fusionProjectId: string = '123') => {
+    const evaluationPage = new EvaluationPage()
+    cy.visitEvaluation(evaluationId, user, fusionProjectId)
+    evaluationPage.progressionStepLink(progression).click()
+})
+
 Cypress.Commands.add('reloadBmt', (user: User, fusionProjectId: string = '123') => {
     /**
      * Situation with reload is quite weird. At the moment all problems are
@@ -105,6 +114,12 @@ declare global {
              * @example cy.visitEvaluation(evaluationId, extHire)
              */
             visitEvaluation(evaluationId: string, user: User, fusionProjectId?: string): Chainable<void>
+
+            /**
+             * Visit evaluation at a specific progression
+             * @example cy.visitProgression(progression, evaluation, user, project)
+             */
+            visitProgression(progression: Progression, evaluationId: string, user: User, fusionProjectId?: string): Chainable<void>
 
             /**
              * Reloads the page and attempts to deal with external dependencies issues

--- a/frontend/cypress/support/testsetup/evaluation_seed.ts
+++ b/frontend/cypress/support/testsetup/evaluation_seed.ts
@@ -136,6 +136,16 @@ export class EvaluationSeed {
         return question.id
     }
 
+    findParticipantByRole(desiredRole: Role) {
+        const participant = this.participants.find(x => {
+            return x.role === desiredRole
+        })
+        if (participant === undefined) {
+            throw 'No user with role ' + desiredRole + ' found'
+        }
+        return participant
+    }
+
     plant() {
         const facilitator = this.participants.find(e => e.role === Role.Facilitator)
         if (facilitator === undefined) {

--- a/frontend/src/components/Disabler.tsx
+++ b/frontend/src/components/Disabler.tsx
@@ -21,6 +21,7 @@ const Disabler = ({ disable, children }: PropsWithChildren<Props>) => {
                         height: '100%',
                         width: '100%',
                     }}
+                    data-testid="disabler_box_div"
                 />
                 {children}
             </div>

--- a/frontend/src/views/Evaluation/Workshop/WorkshopSummaryWithApi.tsx
+++ b/frontend/src/views/Evaluation/Workshop/WorkshopSummaryWithApi.tsx
@@ -47,7 +47,7 @@ const WorkshopSummaryWithApi = ({ evaluation, disable }: React.PropsWithChildren
     }
 
     return (
-        <div style={{ padding: '30px' }}>
+        <div style={{ padding: '30px' }} data-testid="workshop_summary_div">
             <WorkshopSummary localSummary={localSummary} onChange={onChange} savingState={savingState} disable={disable} />
         </div>
     )

--- a/frontend/src/views/Evaluation/Workshop/WorkshopTabs.tsx
+++ b/frontend/src/views/Evaluation/Workshop/WorkshopTabs.tsx
@@ -18,8 +18,8 @@ const WorkshopTabs = ({ children, evaluation }: React.PropsWithChildren<Workshop
     const participant = useParticipant()
 
     return (
-        <Tabs activeTab={activeTab} onChange={setActiveTab}>
-            <List>
+        <Tabs activeTab={activeTab} onChange={setActiveTab} data-testid="workshop_assessment_tabs">
+            <List data-testid="workshop_assessment_tablist">
                 <Tab>Questionaire</Tab>
                 <Tab disabled={!participantCanViewWorkshopSummary(participant)}>Workshop Summary</Tab>
             </List>


### PR DESCRIPTION
Solves #534 

(1) The function `logInUser` I got from actions.ts. Not sure there is a better way to 'import' a function from cypress test.

(2) Having difficulties to test the disabler_box:

In the first test (Facilitator), none of these works, but maybe it is not necessary to test the disabler box anyway:
```

            const disabler_box = cy.getByDataTestid('workshop_summary_div').within(() => {
                cy.getByDataTestid('disabler_box_div')
            })
            expect(disabler_box).to.have.attr('display', 'none')
            expect(disabler_box).to.have.css('display', 'none')
            disabler_box.should('have.css', 'display', 'none')
            disabler_box.should('be.hidden')


```

In addition, it does not raise an error with the following (which is the test run in the test for Participant, but for Facilitator should be `none`).

`            disabler_box.should('have.css', 'display', 'block')
`

The following also did not work:
```
            cy.getByDataTestid('workshop_summary_div').within(() => {
                cy.get('fusion-markdown-editor').should('be.visible')
            })
```
giving the error:

```
AssertionError
Timed out retrying after 4000ms: expected '<fusion-markdown-editor>' to be 'visible'

This element <fusion-markdown-editor> is not visible because it has an effective width and height of: 0 x 0 pixels.
```


For the second test (Participant), the attempt below times out.

`
cy.getByDataTestid('workshop_summary_div').should('be.hidden')
`

but the following works:

```
            cy.getByDataTestid('workshop_summary_div').within(() => {
                cy.get('fusion-markdown-editor').should('be.hidden')
            })

```

If not enough, the disabler_box could be tested, but I am not sure it is the good way because `disabler_box.should('have.css', 'display', 'block')` did not raised any error when testing with Facilitator logged in.

```
           const disabler_box = cy.getByDataTestid('workshop_summary_div').within(() => {
                cy.getByDataTestid('disabler_box_div')
            })
            disabler_box.should('be.visible')
            disabler_box.should('have.css', 'display', 'block')

```

(3) In `workshop_assesssment.ts`, need to fix `WorkshopAssessmentTabs`, the current solution is unstable.

(4) Possibly won't need the data-testid="disabler_box_div", and if needed should be on a different commit.