### PR TITLE
Add / remove project category label to/from question template

### DIFF
--- a/frontend/src/components/Action/EditForm/ActionEditSidebar.tsx
+++ b/frontend/src/components/Action/EditForm/ActionEditSidebar.tsx
@@ -12,6 +12,7 @@ import NotesAndClosingRemarksList from './NotesAndClosingRemarksList'
 import NoteCreateForm from './NoteCreateForm'
 import { useParticipant } from '../../../globals/contexts'
 import { participantCanEditAction } from '../../../utils/RoleBasedAccess'
+import { deriveNewSavingState } from '../../../views/helpers'
 
 const WRITE_DELAY_MS = 1000
 
@@ -68,15 +69,7 @@ const ActionEditSidebar = ({
     }
 
     useEffect(() => {
-        if (isActionSaving) {
-            setSavingState(SavingState.Saving)
-        } else {
-            if (savingState === SavingState.Saving) {
-                setSavingState(SavingState.Saved)
-            } else {
-                setSavingState(SavingState.None)
-            }
-        }
+        setSavingState(deriveNewSavingState(isActionSaving, savingState))
     }, [isActionSaving])
 
     useEffect(() => {

--- a/frontend/src/components/QuestionAndAnswer/QuestionAndAnswerFormWithApi.tsx
+++ b/frontend/src/components/QuestionAndAnswer/QuestionAndAnswerFormWithApi.tsx
@@ -8,6 +8,7 @@ import { useEffectNotOnMount } from '../../utils/hooks'
 import { apiErrorMessage } from '../../api/error'
 import { ApolloError, gql, useMutation } from '@apollo/client'
 import { ANSWER_FIELDS_FRAGMENT, QUESTION_ANSWERS_FRAGMENT } from '../../api/fragments'
+import { deriveNewSavingState } from '../../views/helpers'
 
 interface QuestionAndAnswerFormWithApiProps {
     question: Question
@@ -35,15 +36,7 @@ const QuestionAndAnswerFormWithApi = ({ question, answer, disabled, viewProgress
     const [localSeverity, setLocalSeverity] = useState<Severity>(answer && answer.severity ? answer.severity : Severity.Na)
 
     useEffect(() => {
-        if (loading) {
-            setSavingState(SavingState.Saving)
-        } else {
-            if (savingState === SavingState.Saving) {
-                setSavingState(SavingState.Saved)
-            } else {
-                setSavingState(SavingState.None)
-            }
-        }
+        setSavingState(deriveNewSavingState(loading, savingState))
     }, [loading])
 
     useEffectNotOnMount(() => {

--- a/frontend/src/views/Admin/AdminQuestionItem.tsx
+++ b/frontend/src/views/Admin/AdminQuestionItem.tsx
@@ -13,6 +13,8 @@ interface Props {
     editQuestionTemplate: (data: DataToEditQuestionTemplate) => void
     questionTemplateSaveError: ApolloError | undefined
     projectCategories: ProjectCategory[]
+    isInAddCategoryMode: boolean
+    setIsInAddCategoryMode: (inMode: boolean) => void
 }
 
 const AdminQuestionItem = ({
@@ -21,6 +23,8 @@ const AdminQuestionItem = ({
     isQuestionTemplateSaving,
     questionTemplateSaveError,
     projectCategories,
+    isInAddCategoryMode,
+    setIsInAddCategoryMode,
 }: Props) => {
     const [isInEditmode, setIsInEditmode] = React.useState<boolean>(false)
 
@@ -42,7 +46,13 @@ const AdminQuestionItem = ({
                     questionTemplateSaveError={questionTemplateSaveError}
                 />
             ) : (
-                <StaticQuestionItem question={question} setIsInEditmode={setIsInEditmode} />
+                <StaticQuestionItem
+                    question={question}
+                    setIsInEditmode={setIsInEditmode}
+                    projectCategories={projectCategories}
+                    isInAddCategoryMode={isInAddCategoryMode}
+                    setIsInAddCategoryMode={setIsInAddCategoryMode}
+                />
             )}
         </div>
     )

--- a/frontend/src/views/Admin/AdminView.tsx
+++ b/frontend/src/views/Admin/AdminView.tsx
@@ -11,13 +11,24 @@ import { Barrier, ProjectCategory } from '../../api/models'
 import QuestionListWithApi from './QuestionListWithApi'
 import { barrierToString } from '../../utils/EnumToString'
 import { apiErrorMessage } from '../../api/error'
+import BarrierMenu from './BarrierMenu'
 
 interface Props {}
 
 const AdminView = ({}: Props) => {
     const [selectedBarrier, setSelectedBarrier] = useState<Barrier>(Barrier.Gm)
     const [selectedProjectCategory, setSelectedProjectCategory] = useState<string>('all')
+    const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false)
+    const [isInAddCategoryMode, setIsInAddCategoryMode] = useState<boolean>(false)
     const headerRef = useRef<HTMLElement>(null)
+    const menuAnchorRef = useRef<HTMLButtonElement>(null)
+
+    const openMenu = () => {
+        setIsMenuOpen(true)
+    }
+    const closeMenu = () => {
+        setIsMenuOpen(false)
+    }
 
     const { loading: loadingProjectCategoryQuery, projectCategories, error: errorProjectCategoryQuery } = useGetAllProjectCategoriesQuery()
 
@@ -89,15 +100,29 @@ const AdminView = ({}: Props) => {
                             </Button>
                         </Box>
                         <Box mt={2.5}>
-                            <Button variant="ghost" color="primary">
+                            <Button
+                                variant="ghost"
+                                color="primary"
+                                ref={menuAnchorRef}
+                                onClick={() => (isMenuOpen ? closeMenu() : openMenu())}
+                            >
                                 <Icon data={more_vertical}></Icon>
                             </Button>
                         </Box>
                     </Box>
+                    <BarrierMenu
+                        isOpen={isMenuOpen}
+                        anchorRef={menuAnchorRef}
+                        closeMenu={closeMenu}
+                        setIsInAddCategoryMode={setIsInAddCategoryMode}
+                        isInAddCategoryMode={isInAddCategoryMode}
+                    />
                     <QuestionListWithApi
                         barrier={selectedBarrier}
                         projectCategory={selectedProjectCategory}
                         projectCategories={projectCategories}
+                        isInAddCategoryMode={isInAddCategoryMode}
+                        setIsInAddCategoryMode={setIsInAddCategoryMode}
                     />
                 </Box>
             </Box>

--- a/frontend/src/views/Admin/BarrierMenu.tsx
+++ b/frontend/src/views/Admin/BarrierMenu.tsx
@@ -1,0 +1,30 @@
+import React, { RefObject } from 'react'
+import { Icon, Menu, Typography } from '@equinor/eds-core-react'
+import { add_circle_outlined, close_circle_outlined } from '@equinor/eds-icons'
+
+interface Props {
+    isOpen: boolean
+    anchorRef: RefObject<HTMLButtonElement>
+    closeMenu: () => void
+    setIsInAddCategoryMode: (inEditmode: boolean) => void
+    isInAddCategoryMode: boolean
+}
+
+const BarrierMenu = ({ isOpen, anchorRef, closeMenu, setIsInAddCategoryMode, isInAddCategoryMode }: Props) => {
+    return (
+        <Menu id="menu-complex" open={isOpen} anchorEl={anchorRef.current} onClose={closeMenu} placement={'bottom'}>
+            <Menu.Item
+                onClick={() => {
+                    setIsInAddCategoryMode(!isInAddCategoryMode)
+                }}
+            >
+                <Icon data={isInAddCategoryMode ? close_circle_outlined : add_circle_outlined} size={16} />
+                <Typography group="navigation" variant="menu_title" as="span">
+                    {isInAddCategoryMode ? 'Close category view' : 'Add project categories'}
+                </Typography>
+            </Menu.Item>
+        </Menu>
+    )
+}
+
+export default BarrierMenu

--- a/frontend/src/views/Admin/EditableQuestionItem.tsx
+++ b/frontend/src/views/Admin/EditableQuestionItem.tsx
@@ -102,7 +102,7 @@ const EditableQuestionItem = ({
                 <Box display="flex" flexDirection={'column'}>
                     <Box flexGrow={1}>
                         <SearchableDropdown
-                            label="Responsible discipline"
+                            label="Organization"
                             options={organizationOptions}
                             onSelect={option => setOrganization(option.key as Organization)}
                         />
@@ -112,7 +112,7 @@ const EditableQuestionItem = ({
                             <SaveIndicator savingState={SavingState.Saving} />
                         </Box>
                     )}
-                    <Box alignSelf={'flex-end'}>
+                    <Box alignSelf={'flex-end'} style={{ minWidth: '170px' }}>
                         <Button
                             variant="outlined"
                             style={{ marginRight: '20px' }}

--- a/frontend/src/views/Admin/QuestionListWithApi.tsx
+++ b/frontend/src/views/Admin/QuestionListWithApi.tsx
@@ -11,9 +11,11 @@ interface Props {
     barrier: Barrier
     projectCategory: string
     projectCategories: ProjectCategory[]
+    isInAddCategoryMode: boolean
+    setIsInAddCategoryMode: (inMode: boolean) => void
 }
 
-const QuestionListWithApi = ({ barrier, projectCategory, projectCategories }: Props) => {
+const QuestionListWithApi = ({ barrier, projectCategory, projectCategories, isInAddCategoryMode, setIsInAddCategoryMode }: Props) => {
     const { questions, loading, error, refetch: refetchQuestionTemplates } = useQuestionTemplatesQuery()
     const {
         editQuestionTemplate,
@@ -69,6 +71,8 @@ const QuestionListWithApi = ({ barrier, projectCategory, projectCategories }: Pr
                         isQuestionTemplateSaving={isQuestionTemplateSaving}
                         questionTemplateSaveError={questionTemplateSaveError}
                         projectCategories={projectCategories}
+                        isInAddCategoryMode={isInAddCategoryMode}
+                        setIsInAddCategoryMode={setIsInAddCategoryMode}
                     />
                 )
             })}

--- a/frontend/src/views/Admin/QuestionTemplateMenu.tsx
+++ b/frontend/src/views/Admin/QuestionTemplateMenu.tsx
@@ -1,4 +1,4 @@
-import React, { MutableRefObject, RefObject } from 'react'
+import React, { RefObject } from 'react'
 import { Icon, Menu, Typography } from '@equinor/eds-core-react'
 import { arrow_up, arrow_down, delete_to_trash } from '@equinor/eds-icons'
 

--- a/frontend/src/views/Admin/StaticQuestionItem.tsx
+++ b/frontend/src/views/Admin/StaticQuestionItem.tsx
@@ -1,50 +1,122 @@
 import React, { useRef, useState } from 'react'
 import { tokens } from '@equinor/eds-tokens'
-import { MarkdownViewer } from '@equinor/fusion-components'
-import { Button, Chip, Icon, Tooltip, Typography } from '@equinor/eds-core-react'
+import { MarkdownViewer, TextArea } from '@equinor/fusion-components'
+import { Button, Chip, Icon, MultiSelect, Tooltip, Typography } from '@equinor/eds-core-react'
 import { Box } from '@material-ui/core'
-import { more_vertical, edit, work, platform } from '@equinor/eds-icons'
+import { edit, more_vertical, platform, work } from '@equinor/eds-icons'
 
-import { QuestionTemplate } from '../../api/models'
+import { ProjectCategory, QuestionTemplate } from '../../api/models'
 import { organizationToString } from '../../utils/EnumToString'
 import QuestionTemplateMenu from './QuestionTemplateMenu'
+import { UseMultipleSelectionStateChange } from 'downshift'
+import { ApolloError, gql, useMutation } from '@apollo/client'
+import SaveIndicator from '../../components/SaveIndicator'
+import { SavingState } from '../../utils/Variables'
+import { deriveNewSavingState } from '../helpers'
+import { apiErrorMessage } from '../../api/error'
+import { useEffectNotOnMount } from '../../utils/hooks'
 
 interface Props {
     question: QuestionTemplate
     setIsInEditmode: (inEditmode: boolean) => void
+    projectCategories: ProjectCategory[]
+    isInAddCategoryMode: boolean
+    setIsInAddCategoryMode: (inMode: boolean) => void
 }
 
-const StaticQuestionItem = ({ question, setIsInEditmode }: Props) => {
+const StaticQuestionItem = ({ question, setIsInEditmode, projectCategories, isInAddCategoryMode, setIsInAddCategoryMode }: Props) => {
     const [isOpen, setIsOpen] = useState<boolean>(false)
+    const [savingState, setSavingState] = useState<SavingState>(SavingState.None)
     const anchorRef = useRef<HTMLButtonElement>(null)
+    const projectCategoriesOptions = [...projectCategories].map(category => category.name)
 
-    const openMenu = () => {
-        setIsOpen(true)
+    const {
+        addToProjectCategory,
+        loading: addingToProjectCategory,
+        error: addingToProjectCategoryError,
+    } = useAddToProjectCategoryMutation()
+
+    const {
+        removeFromProjectCategory,
+        loading: removingFromProjectCategory,
+        error: removingFromProjectCategoryError,
+    } = useRemoveFromProjectCategoryMutation()
+
+    useEffectNotOnMount(() => {
+        setSavingState(deriveNewSavingState(addingToProjectCategory, savingState, addingToProjectCategoryError !== undefined))
+    }, [addingToProjectCategory])
+
+    useEffectNotOnMount(() => {
+        setSavingState(deriveNewSavingState(removingFromProjectCategory, savingState, removingFromProjectCategoryError !== undefined))
+    }, [removingFromProjectCategory])
+
+    const checkIfNewItem = (selection: string[]): ProjectCategory | undefined => {
+        let newItem: ProjectCategory | undefined = undefined
+
+        selection.forEach(selectedCategoryString => {
+            if (
+                question.projectCategories.findIndex(questionProjectCategory => questionProjectCategory.name === selectedCategoryString) < 0
+            ) {
+                newItem = projectCategories.find(projectCategory => projectCategory.name === selectedCategoryString)
+            }
+        })
+
+        return newItem
     }
-    const closeMenu = () => {
-        setIsOpen(false)
+
+    const checkIfDeletedItem = (selection: string[]): ProjectCategory | undefined => {
+        let deletedItem = undefined
+
+        question.projectCategories.forEach(questionProjectCategory => {
+            if (selection.findIndex(selectedCategoryString => selectedCategoryString === questionProjectCategory.name) < 0) {
+                deletedItem = questionProjectCategory
+            }
+        })
+
+        return deletedItem
+    }
+
+    const updateProjectCategories = (selection: string[] | undefined) => {
+        if (selection) {
+            const newItemInSelection = checkIfNewItem(selection)
+            const deletedItemInSelection = checkIfDeletedItem(selection)
+
+            if (newItemInSelection) {
+                addToProjectCategory({
+                    questionTemplateId: question.id,
+                    projectCategoryId: newItemInSelection.id,
+                })
+            }
+
+            if (deletedItemInSelection) {
+                removeFromProjectCategory({
+                    questionTemplateId: question.id,
+                    projectCategoryId: deletedItemInSelection.id,
+                })
+            }
+        }
     }
 
     return (
         <>
             <Box display="flex" flexDirection="row">
-                <Box display="flex" flexGrow={1} mb={3} mr={22}>
+                <Box display="flex" flexGrow={1} mb={3} mr={5}>
                     <Box ml={2} mr={1}>
                         <Typography variant="h4">{question.order}.</Typography>
                     </Box>
                     <Box>
                         <Typography variant="h4">{question.text}</Typography>
-                        <Box display="flex" flexDirection="row" mb={3} mt={1}>
-                            <Box mr={1}>
+                        <Box display="flex" flexDirection="row" flexWrap="wrap" mb={2} mt={1} alignItems={'center'}>
+                            <Box mr={1} mb={1}>
                                 <Chip style={{ backgroundColor: tokens.colors.infographic.primary__spruce_wood.rgba }}>
-                                    <Tooltip title={'Responsible discipline'} placement={'bottom'}>
+                                    <Tooltip title={'Organization'} placement={'bottom'}>
                                         <Icon data={work} size={16}></Icon>
                                     </Tooltip>
                                     {organizationToString(question.organization)}
                                 </Chip>
                             </Box>
-                            {question.projectCategories.map(category => (
-                                <Box mr={1}>
+                            {question.projectCategories.map((category, index) => (
+                                <Box mr={1} mb={1} key={index}>
                                     <Chip style={{ backgroundColor: tokens.colors.infographic.primary__mist_blue.rgba }}>
                                         <Tooltip title={'Project category'} placement={'bottom'}>
                                             <Icon data={platform} size={16}></Icon>
@@ -53,24 +125,166 @@ const StaticQuestionItem = ({ question, setIsInEditmode }: Props) => {
                                     </Chip>
                                 </Box>
                             ))}
+                            {isInAddCategoryMode && (
+                                <Box width={200} mb={1}>
+                                    <MultiSelect
+                                        label=""
+                                        items={projectCategoriesOptions}
+                                        initialSelectedItems={question.projectCategories.map(cat => cat.name)}
+                                        handleSelectedItemsChange={(changes: UseMultipleSelectionStateChange<string>) => {
+                                            updateProjectCategories(changes.selectedItems)
+                                        }}
+                                    />
+                                </Box>
+                            )}
                         </Box>
-                        <MarkdownViewer markdown={question.supportNotes} />
+                        <Box mt={3}>
+                            <MarkdownViewer markdown={question.supportNotes} />
+                        </Box>
                     </Box>
                 </Box>
-                <Box>
-                    <Button variant="ghost" color="primary" onClick={() => setIsInEditmode(true)}>
-                        <Icon data={edit}></Icon>
-                    </Button>
+                <Box display="flex" flexDirection={'column'}>
+                    <Box flexGrow={1} style={{ minWidth: '120px' }}>
+                        <Button variant="ghost" color="primary" onClick={() => setIsInEditmode(true)}>
+                            <Icon data={edit}></Icon>
+                        </Button>
+                        <Button
+                            variant="ghost"
+                            color="primary"
+                            ref={anchorRef}
+                            onClick={() => (isOpen ? setIsOpen(false) : setIsOpen(true))}
+                        >
+                            <Icon data={more_vertical}></Icon>
+                        </Button>
+                    </Box>
+                    <Box alignSelf={'flex-end'} mr={2}>
+                        <SaveIndicator savingState={savingState} />
+                    </Box>
                 </Box>
-                <Box>
-                    <Button variant="ghost" color="primary" ref={anchorRef} onClick={() => (isOpen ? closeMenu() : openMenu())}>
-                        <Icon data={more_vertical}></Icon>
-                    </Button>
-                    <QuestionTemplateMenu isOpen={isOpen} anchorRef={anchorRef} closeMenu={closeMenu} />
-                </Box>
+                <QuestionTemplateMenu isOpen={isOpen} anchorRef={anchorRef} closeMenu={() => setIsOpen(false)} />
             </Box>
+            {addingToProjectCategoryError && (
+                <Box mt={2} ml={4}>
+                    <Box>
+                        <TextArea value={apiErrorMessage('Not able to add project category to question template')} onChange={() => {}} />
+                    </Box>
+                </Box>
+            )}
+            {removingFromProjectCategoryError && (
+                <Box mt={2} ml={4}>
+                    <Box>
+                        <TextArea
+                            value={apiErrorMessage('Not able to remove project category from question template')}
+                            onChange={() => {}}
+                        />
+                    </Box>
+                </Box>
+            )}
         </>
     )
 }
 
 export default StaticQuestionItem
+
+export interface DataToAddToOrRemoveFromProjectCategory {
+    questionTemplateId: string
+    projectCategoryId: string
+}
+
+interface AddToProjectCategoryMutationProps {
+    addToProjectCategory: (data: DataToAddToOrRemoveFromProjectCategory) => void
+    loading: boolean
+    error: ApolloError | undefined
+}
+
+const useAddToProjectCategoryMutation = (): AddToProjectCategoryMutationProps => {
+    const ADD_TO_PROJECT_CATEGORY = gql`
+        mutation AddToProjectCategory($questionTemplateId: String!, $projectCategoryId: String!) {
+            addToProjectCategory(questionTemplateId: $questionTemplateId, projectCategoryId: $projectCategoryId) {
+                id
+                projectCategories {
+                    id
+                    name
+                }
+            }
+        }
+    `
+
+    const [addToProjectCategoryApolloFunc, { loading, data, error }] = useMutation(ADD_TO_PROJECT_CATEGORY, {
+        update(cache, mutationResult) {
+            const questionTemplateAddedTo = mutationResult.data.addToProjectCategory
+            cache.modify({
+                id: cache.identify({
+                    __typename: 'QuestionTemplate',
+                    id: questionTemplateAddedTo.id,
+                }),
+                fields: {
+                    projectCategories() {
+                        return questionTemplateAddedTo.projectCategories
+                    },
+                },
+            })
+        },
+    })
+
+    const addToProjectCategory = (data: DataToAddToOrRemoveFromProjectCategory) => {
+        addToProjectCategoryApolloFunc({
+            variables: { ...data },
+        })
+    }
+
+    return {
+        addToProjectCategory,
+        loading,
+        error,
+    }
+}
+
+interface RemoveFromProjectCategoryMutationProps {
+    removeFromProjectCategory: (data: DataToAddToOrRemoveFromProjectCategory) => void
+    loading: boolean
+    error: ApolloError | undefined
+}
+
+const useRemoveFromProjectCategoryMutation = (): RemoveFromProjectCategoryMutationProps => {
+    const REMOVE_FROM_PROJECT_CATEGORY = gql`
+        mutation RemoveFromProjectCategory($questionTemplateId: String!, $projectCategoryId: String!) {
+            removeFromProjectCategory(questionTemplateId: $questionTemplateId, projectCategoryId: $projectCategoryId) {
+                id
+                projectCategories {
+                    id
+                    name
+                }
+            }
+        }
+    `
+
+    const [removeFromProjectCategoryApolloFunc, { loading, data, error }] = useMutation(REMOVE_FROM_PROJECT_CATEGORY, {
+        update(cache, mutationResult) {
+            const questionTemplateRemovedFrom = mutationResult.data.removeFromProjectCategory
+            cache.modify({
+                id: cache.identify({
+                    __typename: 'QuestionTemplate',
+                    id: questionTemplateRemovedFrom.id,
+                }),
+                fields: {
+                    projectCategories() {
+                        return questionTemplateRemovedFrom.projectCategories
+                    },
+                },
+            })
+        },
+    })
+
+    const removeFromProjectCategory = (data: DataToAddToOrRemoveFromProjectCategory) => {
+        removeFromProjectCategoryApolloFunc({
+            variables: { ...data },
+        })
+    }
+
+    return {
+        removeFromProjectCategory,
+        loading,
+        error,
+    }
+}

--- a/frontend/src/views/Evaluation/Workshop/WorkshopSummaryWithApi.tsx
+++ b/frontend/src/views/Evaluation/Workshop/WorkshopSummaryWithApi.tsx
@@ -6,6 +6,7 @@ import { Evaluation } from '../../../api/models'
 import { useEffectNotOnMount } from '../../../utils/hooks'
 import { SavingState } from '../../../utils/Variables'
 import WorkshopSummary from './WorkshopSummary'
+import { deriveNewSavingState } from '../../helpers'
 
 const WRITE_DELAY_MS = 1000
 
@@ -25,15 +26,7 @@ const WorkshopSummaryWithApi = ({ evaluation, disable }: React.PropsWithChildren
     }
 
     useEffect(() => {
-        if (loading) {
-            setSavingState(SavingState.Saving)
-        } else {
-            if (savingState === SavingState.Saving) {
-                setSavingState(SavingState.Saved)
-            } else {
-                setSavingState(SavingState.None)
-            }
-        }
+        setSavingState(deriveNewSavingState(loading, savingState))
     }, [loading])
 
     useEffectNotOnMount(() => {
@@ -55,12 +48,7 @@ const WorkshopSummaryWithApi = ({ evaluation, disable }: React.PropsWithChildren
 
     return (
         <div style={{ padding: '30px' }}>
-            <WorkshopSummary 
-                localSummary={localSummary} 
-                onChange={onChange} 
-                savingState={savingState} 
-                disable={disable} 
-            />
+            <WorkshopSummary localSummary={localSummary} onChange={onChange} savingState={savingState} disable={disable} />
         </div>
     )
 }

--- a/frontend/src/views/helpers.ts
+++ b/frontend/src/views/helpers.ts
@@ -1,5 +1,6 @@
 import { Progression, Question } from '../api/models'
 import { Validity } from '../components/Action/utils'
+import { SavingState } from '../utils/Variables'
 
 export const isQuestionStillInView = (selectedQuestionElement: HTMLElement | null, topPlacementInPixels: number | null) => {
     if (selectedQuestionElement !== null && topPlacementInPixels !== null) {
@@ -90,6 +91,20 @@ export const updateValidity = (isFieldValid: boolean, validityStatus: Validity, 
     } else if (validityStatus === 'success') {
         if (!isFieldValid) {
             setValidity('error')
+        }
+    }
+}
+
+export const deriveNewSavingState = (isLoading: boolean, currentSavingState: SavingState, errorHappened = false) => {
+    if (isLoading) {
+        return SavingState.Saving
+    } else {
+        if (currentSavingState === SavingState.Saving && !errorHappened) {
+            return SavingState.Saved
+        } else if (!errorHappened) {
+            return SavingState.None
+        } else {
+            return SavingState.NotSaved
         }
     }
 }


### PR DESCRIPTION
With this pull request it will be possible to add and remove a project category label to/from a question template (i.e. add/ remove question template from project category). The view looks like this:

![image](https://user-images.githubusercontent.com/1130244/134483552-fff85a54-27b8-4930-9b66-5cb1bb10959a.png)

By clicking the menu element next to the Barrier name, all questions in the barrier are made editable. It is now possible to select or deselect elements from the dropdown. Every selection triggers one API-call, either to add or remove.

**Features of this PR:**
* Frontend for adding and deleting as described above
* GraphQL mutations for adding and deleting
* Save-indicator on each question when saving
* Error message if saving fails
* Caching of results
* I also made a helper for some code that was used in several components, and used the helper in these "old" components as well

**Known potential problems**
* If an error occurs when saving or deleting a project category, an error message will appear, but there will also be an inconsistency in the select-dropdown and the actual tagged projects (shown in the amount of chips). For instance: If your question template has two categories, it will have two category-chips. If you want to remove one of the categories, and you deselect the category in the dropdown, but the call fails, the deselected category will still be deselected in the dropdown, but the number of chips will still be two chips, since no category has been deleted in the DB. This also happens when adding fails. _This is not fixed because it's because of how the Multiple Select handles its data, and I didn't want to spend time on something that might not be an issue. In my opinion, it's not important, since the inconsistency just highlights that the save failed, and the chips (and the text) reflect if the category really were added / deleted. When the edit-mode is closed, the inconsistency will no longer exist._

Illustration of problem:
![image](https://user-images.githubusercontent.com/1130244/134485471-06b04a65-41c4-48c7-a6e3-d8344fca1468.png)

Edit: Changed so that a "Not Saved"-status makes it even more clear that the change in the dropdown has not reached the DB:

![image](https://user-images.githubusercontent.com/1130244/134488266-7d218546-c349-4011-9d66-5923a87864f7.png)
