### PR TITLE
Create new project category

### DIFF
--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -282,7 +282,7 @@ namespace api.GQL
 
         public ProjectCategory CopyProjectCategory(string newName, string projectCategoryId)
         {
-            var other = _projectCategoryService.Get(projectCategoryId);
+            var other = _projectCategoryService.GetAll().Include(x => x.QuestionTemplates).Single(x => x.Id ==projectCategoryId);
             return _projectCategoryService.CopyFrom(newName, other);
         }
 

--- a/backend/api/GQL/Mutation.cs
+++ b/backend/api/GQL/Mutation.cs
@@ -286,9 +286,16 @@ namespace api.GQL
             return _projectCategoryService.CopyFrom(newName, other);
         }
 
-        public QuestionTemplate CreateQuestionTemplate(Barrier barrier, Organization organization, string text, string supportNotes)
+        public QuestionTemplate CreateQuestionTemplate(Barrier barrier, Organization organization, string text, string supportNotes, string[] projectCategoryIds)
         {
-            return _questionTemplateService.Create(barrier, organization, text, supportNotes);
+            var qt = _questionTemplateService.Create(barrier, organization, text, supportNotes);
+
+            foreach (var projectCategoryId in projectCategoryIds)
+            {
+                _questionTemplateService.AddToProjectCategory(qt.Id, projectCategoryId);
+            }
+
+            return qt;
         }
 
         public QuestionTemplate EditQuestionTemplate(
@@ -306,11 +313,11 @@ namespace api.GQL
                 .Single(x => x.Id == questionTemplateId)
             ;
             return _questionTemplateService.Edit(
-                questionTemplate, 
-                barrier, 
-                organization, 
-                text, 
-                supportNotes, 
+                questionTemplate,
+                barrier,
+                organization,
+                text,
+                supportNotes,
                 status
             );
         }

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -463,6 +463,7 @@ export type MutationCreateQuestionTemplateArgs = {
   organization: Organization;
   text?: Maybe<Scalars['String']>;
   supportNotes?: Maybe<Scalars['String']>;
+  projectCategoryIds?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 

--- a/frontend/src/views/Admin/AdminQuestionItem.tsx
+++ b/frontend/src/views/Admin/AdminQuestionItem.tsx
@@ -11,19 +11,11 @@ interface Props {
     question: QuestionTemplate
     projectCategories: ProjectCategory[]
     isInAddCategoryMode: boolean
-    setIsInAddCategoryMode: (inMode: boolean) => void
     questionTitleRef: RefObject<HTMLElement>
     refetchQuestionTemplates: () => void
 }
 
-const AdminQuestionItem = ({
-    question,
-    projectCategories,
-    isInAddCategoryMode,
-    setIsInAddCategoryMode,
-    questionTitleRef,
-    refetchQuestionTemplates
-}: Props) => {
+const AdminQuestionItem = ({ question, projectCategories, isInAddCategoryMode, questionTitleRef, refetchQuestionTemplates }: Props) => {
     const [isInEditmode, setIsInEditmode] = React.useState<boolean>(false)
 
     const {
@@ -59,7 +51,6 @@ const AdminQuestionItem = ({
                     setIsInEditmode={setIsInEditmode}
                     projectCategories={projectCategories}
                     isInAddCategoryMode={isInAddCategoryMode}
-                    setIsInAddCategoryMode={setIsInAddCategoryMode}
                     questionTitleRef={questionTitleRef}
                 />
             )}

--- a/frontend/src/views/Admin/BarrierMenu.tsx
+++ b/frontend/src/views/Admin/BarrierMenu.tsx
@@ -20,7 +20,7 @@ const BarrierMenu = ({ isOpen, anchorRef, closeMenu, setIsInAddCategoryMode, isI
             >
                 <Icon data={isInAddCategoryMode ? close_circle_outlined : add_circle_outlined} size={16} />
                 <Typography group="navigation" variant="menu_title" as="span">
-                    {isInAddCategoryMode ? 'Close category view' : 'Add project categories'}
+                    {isInAddCategoryMode ? 'Close add to category view' : 'Add questions to project categories'}
                 </Typography>
             </Menu.Item>
         </Menu>

--- a/frontend/src/views/Admin/CreateProjectCategorySidebar.tsx
+++ b/frontend/src/views/Admin/CreateProjectCategorySidebar.tsx
@@ -1,0 +1,189 @@
+import React, { useState } from 'react'
+import { ApolloError, gql, useMutation } from '@apollo/client'
+import { ModalSideSheet, SearchableDropdown, SearchableDropdownOption } from '@equinor/fusion-components'
+import { Button, TextField, Typography } from '@equinor/eds-core-react'
+import { Grid } from '@material-ui/core'
+import { tokens } from '@equinor/eds-tokens'
+
+import { useSavingStateCheck, useValidityCheck } from '../../utils/hooks'
+import { ErrorIcon, TextFieldChangeEvent } from '../../components/Action/utils'
+import { ProjectCategory } from '../../api/models'
+import { apiErrorMessage } from '../../api/error'
+import SaveIndicator from '../../components/SaveIndicator'
+
+interface Props {
+    isOpen: boolean
+    setIsOpen: (val: boolean) => void
+    onProjectCategoryCreated: (value: string, value2: boolean) => void
+    projectCategories: ProjectCategory[]
+}
+
+const CreateProjectCategorySidebar = ({ isOpen, setIsOpen, onProjectCategoryCreated, projectCategories }: Props) => {
+    const [projectCategoryName, setProjectCategoryName] = useState<string>('')
+    const [projectCategoryToCopy, setProjectCategoryToCopy] = useState<string>('')
+    const { createProjectCategory, projectCategory, loading, error } = useCreateProjectCategoryMutation()
+    const {
+        copyProjectCategory,
+        projectCategory: projectCategoryFromCopy,
+        loading: isCreatingProjectCategoryCopy,
+        error: errorCreatingProjectCategoryCopy,
+    } = useCopyProjectCategoryMutation()
+
+    const isNameValid = () => projectCategoryName.length > 0
+
+    const doWhenProjectCategorySaved = () => {
+        if (projectCategoryToCopy) {
+            onProjectCategoryCreated(projectCategoryFromCopy.id, true)
+        } else {
+            onProjectCategoryCreated(projectCategory.id, false)
+        }
+    }
+
+    const { valueValidity } = useValidityCheck<string>(projectCategoryName, isNameValid)
+    const { savingState } = useSavingStateCheck(
+        loading || isCreatingProjectCategoryCopy,
+        error !== undefined || errorCreatingProjectCategoryCopy !== undefined,
+        doWhenProjectCategorySaved
+    )
+
+    const projectCategoryOptions: SearchableDropdownOption[] = []
+
+    projectCategories.forEach((projectCategory: ProjectCategory) =>
+        projectCategoryOptions.push({
+            title: projectCategory.name,
+            key: projectCategory.id,
+            isSelected: projectCategory.id === projectCategoryToCopy,
+        })
+    )
+
+    const onCreateProjectCategory = () => {
+        if (projectCategoryToCopy) {
+            copyProjectCategory(projectCategoryName, projectCategoryToCopy)
+        } else {
+            createProjectCategory(projectCategoryName)
+        }
+    }
+
+    return (
+        <ModalSideSheet
+            header={`Create Project Category`}
+            show={isOpen}
+            size="medium"
+            onClose={() => {
+                setIsOpen(false)
+            }}
+            isResizable={false}
+            headerIcons={[<SaveIndicator savingState={savingState} />]}
+        >
+            <Grid container style={{ padding: 20 }}>
+                <Grid item xs={12}>
+                    <TextField
+                        id="name"
+                        value={projectCategoryName}
+                        autoFocus={true}
+                        label="Name"
+                        onChange={(event: TextFieldChangeEvent) => {
+                            setProjectCategoryName(event.target.value)
+                        }}
+                        variant={valueValidity}
+                        helperText={valueValidity === 'error' ? 'required' : ''}
+                        helperIcon={valueValidity === 'error' ? ErrorIcon : <></>}
+                    />
+                </Grid>
+                <Grid item xs={12} style={{ marginTop: 20 }}>
+                    <SearchableDropdown
+                        label="Add questions from project category (optional)"
+                        placeholder="Add questions from project category (optional)"
+                        onSelect={option => setProjectCategoryToCopy(option.key)}
+                        options={projectCategoryOptions}
+                    />
+                </Grid>
+                <Grid container justify="flex-end" style={{ marginTop: '20px' }}>
+                    <Button variant="outlined" style={{ marginRight: '10px' }} onClick={() => setIsOpen(false)} disabled={loading}>
+                        Cancel
+                    </Button>
+                    <Button onClick={onCreateProjectCategory} disabled={!isNameValid() || loading}>
+                        Save
+                    </Button>
+                </Grid>
+                {error !== undefined && (
+                    <Grid item xs={12}>
+                        <div
+                            style={{
+                                marginTop: 20,
+                                backgroundColor: tokens.colors.ui.background__light.rgba,
+                                padding: '10px',
+                            }}
+                        >
+                            <Typography>{apiErrorMessage('Could not save Project Category')}</Typography>
+                        </div>
+                    </Grid>
+                )}
+            </Grid>
+        </ModalSideSheet>
+    )
+}
+
+export default CreateProjectCategorySidebar
+
+interface CreateProjectCategoryMutationProps {
+    createProjectCategory: (name: string) => void
+    projectCategory: ProjectCategory
+    loading: boolean
+    error: ApolloError | undefined
+}
+
+const useCreateProjectCategoryMutation = (): CreateProjectCategoryMutationProps => {
+    const CREATE_PROJECT_CATEGORY = gql`
+        mutation CreateProjectCategory($name: String!) {
+            createProjectCategory(name: $name) {
+                id
+                name
+            }
+        }
+    `
+
+    const [createProjectCategoryApolloFunc, { data, loading, error }] = useMutation(CREATE_PROJECT_CATEGORY)
+
+    const createProjectCategory = (name: string) => {
+        createProjectCategoryApolloFunc({ variables: { name } })
+    }
+
+    return {
+        createProjectCategory,
+        projectCategory: data && data.createProjectCategory,
+        loading,
+        error,
+    }
+}
+
+interface CopyProjectCategoryMutationProps {
+    copyProjectCategory: (name: string, projectCategoryId: string) => void
+    projectCategory: ProjectCategory
+    loading: boolean
+    error: ApolloError | undefined
+}
+
+const useCopyProjectCategoryMutation = (): CopyProjectCategoryMutationProps => {
+    const COPY_PROJECT_CATEGORY = gql`
+        mutation CopyProjectCategory($newName: String!, $projectCategoryId: String!) {
+            copyProjectCategory(newName: $newName, projectCategoryId: $projectCategoryId) {
+                id
+                name
+            }
+        }
+    `
+
+    const [copyProjectCategoryApolloFunc, { data, loading, error }] = useMutation(COPY_PROJECT_CATEGORY)
+
+    const copyProjectCategory = (name: string, projectCategoryId: string) => {
+        copyProjectCategoryApolloFunc({ variables: { newName: name, projectCategoryId } })
+    }
+
+    return {
+        copyProjectCategory,
+        projectCategory: data && data.copyProjectCategory,
+        loading,
+        error,
+    }
+}

--- a/frontend/src/views/Admin/StaticQuestionItem.tsx
+++ b/frontend/src/views/Admin/StaticQuestionItem.tsx
@@ -21,18 +21,10 @@ interface Props {
     setIsInEditmode: (inEditmode: boolean) => void
     projectCategories: ProjectCategory[]
     isInAddCategoryMode: boolean
-    setIsInAddCategoryMode: (inMode: boolean) => void
     questionTitleRef: RefObject<HTMLElement>
 }
 
-const StaticQuestionItem = ({
-    question,
-    setIsInEditmode,
-    projectCategories,
-    isInAddCategoryMode,
-    setIsInAddCategoryMode,
-    questionTitleRef,
-}: Props) => {
+const StaticQuestionItem = ({ question, setIsInEditmode, projectCategories, isInAddCategoryMode, questionTitleRef }: Props) => {
     const [isOpen, setIsOpen] = useState<boolean>(false)
     const [savingState, setSavingState] = useState<SavingState>(SavingState.None)
     const anchorRef = useRef<HTMLButtonElement>(null)
@@ -113,7 +105,7 @@ const StaticQuestionItem = ({
                         <Typography variant="h4">{question.order}.</Typography>
                     </Box>
                     <Box>
-                        <Typography variant="h4" data-testid={'question-title-' + question.order}>
+                        <Typography variant="h4" ref={questionTitleRef} data-testid={'question-title-' + question.order}>
                             {question.text}
                         </Typography>
                         <Box display="flex" flexDirection="row" flexWrap="wrap" mb={2} mt={1} alignItems={'center'}>


### PR DESCRIPTION
**Issue**: Make it possible to create a new project category through the admin panel.

**The solution flow:**

1) Click "Add project category" button at the top right

![image](https://user-images.githubusercontent.com/1130244/134893400-6af94bf6-c5e6-4e38-a226-9b7b6f907109.png)

2) In the side panel that opens, type a name for the project category. It is not possible to click the save-button if the field is empty, and if the field is erased after typing something, the field will get an error message in addition to the disabled save-button. It is also possible to select a project category in the field below, but let's look at that later. After typing a name, click save.

![image](https://user-images.githubusercontent.com/1130244/135101564-2c96916b-f937-4a7f-a5d9-91ae8580d1ae.png)

3) After clicking save, the side panel will close, and the new project category will be selected in the project category dropdown. Since the category doesn't have any questions yet, a message will be visible, describing how to get questions into the category. All the same barriers are visible.

![image](https://user-images.githubusercontent.com/1130244/135101748-9229de27-e70c-4c0e-986e-a67b77fd22ac.png)

4) As stated in the text, it is possible to add new questions, and a new feature from this PR is that they will automatically be added to the new project category, since this is selected in the dropdown:

![image](https://user-images.githubusercontent.com/1130244/135102106-3d2b7661-a951-4182-8f6f-98802342953d.png)

![image](https://user-images.githubusercontent.com/1130244/135102161-c47a6a43-c67d-470c-b105-d2fb9de2dad5.png)

(notice the "Butterfly" tag on the question template, and the fact that it is the only question listed as Butterfly is selected)

5) It is also possible to add a new project category from a "copy" of another project category. This means that all question templates that is tagged with the other project category, will now be tagged with the new project category. To achieve this we select the project category from the dropdown in the create-sideview:

![image](https://user-images.githubusercontent.com/1130244/135102604-8f277bec-67da-467b-bcb9-ada615fa0912.png)

6) As we can see, the new project category has the same question as the one we made earlier (notice the tags):

![image](https://user-images.githubusercontent.com/1130244/135102702-633611ec-ba1e-4d39-88ff-e3f4fbb6c315.png)

To sum up, this PR gives:
* Possibility to create a new project category in the UI
* Possibility to make a new project category that has all the question templates that a selected other project category has
* New question templates are now assigned to the selected project category

