### PR TITLE
Now possible to delete project category

### DIFF
--- a/frontend/src/components/ConfirmationDialog.tsx
+++ b/frontend/src/components/ConfirmationDialog.tsx
@@ -1,15 +1,17 @@
-import { Button, Dialog, Scrim, Typography } from '@equinor/eds-core-react'
+import React from 'react'
 import { Box } from '@material-ui/core'
+import { Button, CircularProgress, Dialog, Scrim, Typography } from '@equinor/eds-core-react'
 
 interface ConfirmationDialogProps {
     isOpen: boolean
+    isLoading?: boolean
     title: string
     description?: string
     onConfirmClick: () => void
     onCancelClick: () => void
 }
 
-const ConfirmationDialog = ({ isOpen, title, description, onConfirmClick, onCancelClick }: ConfirmationDialogProps) => {
+const ConfirmationDialog = ({ isOpen, isLoading = false, title, description, onConfirmClick, onCancelClick }: ConfirmationDialogProps) => {
     if (!isOpen) {
         return <></>
     }
@@ -19,7 +21,12 @@ const ConfirmationDialog = ({ isOpen, title, description, onConfirmClick, onCanc
             <Scrim isDismissable={true} onClose={onCancelClick}>
                 <Dialog data-testid="confirmation_dialog">
                     <Dialog.Title>{title}</Dialog.Title>
-                    {description && (
+                    {isLoading && (
+                        <Box display={'flex'} alignItems={'center'} justifyContent={'center'} mt={2} mb={4}>
+                            <CircularProgress style={{ width: '25px', height: '25px' }} />
+                        </Box>
+                    )}
+                    {!isLoading && description && (
                         <Dialog.CustomContent>
                             <Typography>{description}</Typography>
                         </Dialog.CustomContent>
@@ -32,12 +39,12 @@ const ConfirmationDialog = ({ isOpen, title, description, onConfirmClick, onCanc
                     >
                         <Box display="flex" flexDirection="row">
                             <Box flexGrow={1}>
-                                <Button data-testid="no_button" onClick={onCancelClick}>
+                                <Button data-testid="no_button" onClick={onCancelClick} disabled={isLoading}>
                                     No
                                 </Button>
                             </Box>
                             <Box>
-                                <Button data-testid="yes_button" variant="ghost" onClick={onConfirmClick}>
+                                <Button data-testid="yes_button" variant="ghost" onClick={onConfirmClick} disabled={isLoading}>
                                     Yes
                                 </Button>
                             </Box>

--- a/frontend/src/views/Admin/CategoryHeader.tsx
+++ b/frontend/src/views/Admin/CategoryHeader.tsx
@@ -1,10 +1,14 @@
 import React, { useState } from 'react'
 import { Box } from '@material-ui/core'
+import { ApolloError, gql, useMutation } from '@apollo/client'
 import { SearchableDropdown, SearchableDropdownOption } from '@equinor/fusion-components'
-import { Button, Icon } from '@equinor/eds-core-react'
-import { add } from '@equinor/eds-icons'
+import { Button, Icon, Tooltip } from '@equinor/eds-core-react'
+import { add, delete_to_trash } from '@equinor/eds-icons'
 
 import { ProjectCategory } from '../../api/models'
+import { useEffectNotOnMount } from '../../utils/hooks'
+import ConfirmationDialog from '../../components/ConfirmationDialog'
+import ErrorMessage from './Components/ErrorMessage'
 import CreateProjectCategorySidebar from './CreateProjectCategorySidebar'
 
 interface Props {
@@ -23,6 +27,27 @@ const CategoryHeader = ({
     refetchQuestionTemplates,
 }: Props) => {
     const [isInCreateProjectCategoryMode, setIsInCreateProjectCategoryMode] = useState<boolean>(false)
+    const [isInConfirmDeleteMode, setIsInConfirmDeleteMode] = useState<boolean>(false)
+    const [showErrorMessage, setShowErrorMessage] = useState<boolean>(false)
+
+    const {
+        deleteProjectCategory,
+        loading: deletingProjectCategory,
+        error: deletingProjectCategoryError,
+    } = useDeleteProjectCategoryMutation()
+
+    useEffectNotOnMount(() => {
+        if (!deletingProjectCategory) {
+            setIsInConfirmDeleteMode(false)
+            setSelectedProjectCategory('all')
+        }
+    }, [deletingProjectCategory])
+
+    useEffectNotOnMount(() => {
+        if (deletingProjectCategoryError !== undefined) {
+            setShowErrorMessage(true)
+        }
+    }, [deletingProjectCategoryError])
 
     const projectCategoryOptions: SearchableDropdownOption[] = [
         {
@@ -40,6 +65,16 @@ const CategoryHeader = ({
         })
     )
 
+    const createDeleteConfirmation = () => {
+        const projectCategory = projectCategories.find(pc => pc.id === selectedProjectCategory)
+
+        if (projectCategory) {
+            return 'Are you sure you want to delete the project category: ' + "'" + projectCategory.name + "'?"
+        }
+
+        return 'Are you sure you want to delete the selected project category?'
+    }
+
     const onCreated = (projectCategory: string, isCopy: boolean) => {
         setIsInCreateProjectCategoryMode(false)
         refetchProjectCategories()
@@ -51,22 +86,51 @@ const CategoryHeader = ({
 
     return (
         <>
-            <Box flexGrow={1}>
-                <Box ml={4} width={'250px'}>
-                    <SearchableDropdown
-                        label="Project Category"
-                        placeholder="Select Project Category"
-                        onSelect={option => setSelectedProjectCategory(option.key)}
-                        options={projectCategoryOptions}
-                    />
+            <Box display={'flex'} flexDirection={'column'} width={'100%'}>
+                <Box display={'flex'} flexDirection={'row'}>
+                    <Box flexGrow={1}>
+                        <Box ml={4} width={'250px'}>
+                            <SearchableDropdown
+                                label="Project Category"
+                                placeholder="Select Project Category"
+                                onSelect={option => setSelectedProjectCategory(option.key)}
+                                options={projectCategoryOptions}
+                            />
+                        </Box>
+                    </Box>
+                    <Box alignSelf={'center'}>
+                        <Button variant="outlined" onClick={() => setIsInCreateProjectCategoryMode(true)}>
+                            <Icon data={add}></Icon>
+                            Add project category
+                        </Button>
+                    </Box>
+                    <Box mr={4} ml={1} alignSelf={'center'}>
+                        <Tooltip placement="bottom" title={'Delete selected project category'}>
+                            <Button
+                                variant="ghost"
+                                color="primary"
+                                onClick={() => setIsInConfirmDeleteMode(true)}
+                                disabled={selectedProjectCategory === 'all'}
+                            >
+                                <Icon data={delete_to_trash}></Icon>
+                            </Button>
+                        </Tooltip>
+                    </Box>
                 </Box>
+                {showErrorMessage && (
+                    <Box mt={1} ml={4} mr={4}>
+                        <ErrorMessage text={'Could not delete project category'} onClose={() => setShowErrorMessage(false)} />
+                    </Box>
+                )}
             </Box>
-            <Box alignSelf={'center'} mr={4}>
-                <Button variant="outlined" onClick={() => setIsInCreateProjectCategoryMode(true)}>
-                    <Icon data={add}></Icon>
-                    Add project category
-                </Button>
-            </Box>
+            <ConfirmationDialog
+                isOpen={isInConfirmDeleteMode}
+                isLoading={deletingProjectCategory}
+                title={'Delete project category'}
+                description={createDeleteConfirmation()}
+                onConfirmClick={() => deleteProjectCategory(selectedProjectCategory)}
+                onCancelClick={() => setIsInConfirmDeleteMode(false)}
+            />
             {isInCreateProjectCategoryMode && (
                 <CreateProjectCategorySidebar
                     isOpen={isInCreateProjectCategoryMode}
@@ -80,3 +144,42 @@ const CategoryHeader = ({
 }
 
 export default CategoryHeader
+
+interface DeleteProjectCategoryMutationProps {
+    deleteProjectCategory: (projectCategoryId: string) => void
+    loading: boolean
+    error: ApolloError | undefined
+}
+
+const useDeleteProjectCategoryMutation = (): DeleteProjectCategoryMutationProps => {
+    const DELETE_PROJECT_CATEGORY = gql`
+        mutation DeleteProjectCategory($projectCategoryId: String!) {
+            deleteProjectCategory(projectCategoryId: $projectCategoryId) {
+                id
+            }
+        }
+    `
+
+    const [deleteProjectCategoryApolloFunc, { loading, data, error }] = useMutation(DELETE_PROJECT_CATEGORY, {
+        update(cache, mutationResult) {
+            const projectCategoryDeleted = mutationResult.data.deleteProjectCategory
+            const id = cache.identify({
+                __typename: 'ProjectCategory',
+                id: projectCategoryDeleted.id,
+            })
+            cache.evict({ id })
+        },
+    })
+
+    const deleteProjectCategory = (projectCategoryId: string) => {
+        deleteProjectCategoryApolloFunc({
+            variables: { projectCategoryId },
+        })
+    }
+
+    return {
+        deleteProjectCategory,
+        loading,
+        error,
+    }
+}

--- a/frontend/src/views/Admin/Components/ErrorMessage.tsx
+++ b/frontend/src/views/Admin/Components/ErrorMessage.tsx
@@ -1,21 +1,34 @@
+import React from 'react'
+import { Box } from '@material-ui/core'
 import { tokens } from '@equinor/eds-tokens'
+import { Icon, Typography } from '@equinor/eds-core-react'
+import { close } from '@equinor/eds-icons'
 import { apiErrorMessage } from '../../../api/error'
-import { Typography } from '@equinor/eds-core-react'
 
 interface Props {
     text: string
+    onClose?: () => void
 }
 
-const ErrorMessage = ({ text }: Props) => {
+const ErrorMessage = ({ text, onClose }: Props) => {
     return (
-        <div
+        <Box
+            display={'flex'}
+            flexDirection={'row'}
             style={{
                 backgroundColor: tokens.colors.ui.background__light.rgba,
                 padding: '10px',
             }}
         >
-            <Typography>{apiErrorMessage(text)}</Typography>
-        </div>
+            <Box flexGrow={1}>
+                <Typography>{apiErrorMessage(text)}</Typography>
+            </Box>
+            {onClose && (
+                <Box alignSelf={'center'}>
+                    <Icon data={close} size={16} cursor={'pointer'} onClick={onClose}></Icon>
+                </Box>
+            )}
+        </Box>
     )
 }
 


### PR DESCRIPTION
Looks like this:

![image](https://user-images.githubusercontent.com/1130244/135834418-8e68e591-7060-400c-9560-75b3221ec7ca.png)

![image](https://user-images.githubusercontent.com/1130244/135834490-6479741d-e0a9-44a7-8d50-0d66598e05f5.png)

Includes:
* Error handling (the Error box can now be closed if the component that uses it provides an onClose-function)
* A spinner in the confirmation box while saving if the component that uses it provides a loading-variable