### PR TITLE
Bugfix: QT buttons now stays on same line

### DIFF
--- a/frontend/src/views/Admin/Components/QuestionTemplateButtons.tsx
+++ b/frontend/src/views/Admin/Components/QuestionTemplateButtons.tsx
@@ -26,7 +26,7 @@ const QuestionTemplateButtons = ({
     }
 
     return (
-        <Box flexGrow={1} style={{ minWidth: '120px' }}>
+        <Box flexGrow={1} style={{ minWidth: '175px' }}>
             <Tooltip placement="bottom" title="Edit question">
                 <Button
                     variant="ghost"


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1130244/137446800-bc80e118-7794-4f56-abd9-e3a8921a9de9.png)

After:

![image](https://user-images.githubusercontent.com/1130244/137447018-a2402049-cc85-4e82-8afa-ec44df6ef57f.png)
