### PR TITLE
Add test hidden evals are displayed in hidden tab

### DIFF
--- a/frontend/cypress/integration/landing_page_spec.ts
+++ b/frontend/cypress/integration/landing_page_spec.ts
@@ -110,7 +110,7 @@ describe('Landing page', () => {
             cy.visitProject(user, fusionProject1.id)
         })
         context('My evaluations are listed regardless of status and project', () => {
-            it(`All evaluations of user is listed under my evaluations - irrespective of status and project`, () => {
+            it(`All evaluations of user are listed under my evaluations - irrespective of status and project`, () => {
                 cy.get(`[data-testid=project-table]`).within(() => {
                     evaluations.forEach(t => {
                         const evalName = t.evaluation.name

--- a/frontend/cypress/integration/landing_page_spec.ts
+++ b/frontend/cypress/integration/landing_page_spec.ts
@@ -89,7 +89,7 @@ describe('Landing page', () => {
         status: Status.Voided,
     })
 
-    before(() => {
+    before('Plant (load into DB) all evaluations', () => {
         myActiveEvaluationInProject.plant()
         notMyActiveEvaluationInProject.plant()
         myActiveEvaluationNotInProject.plant()
@@ -107,7 +107,7 @@ describe('Landing page', () => {
 
     context(`Dashboard `, () => {
         context('My evaluations (only my evaluations are listed) regardless of status and project', () => {
-            before(() => {
+            before('Log in as user', () => {
                 cy.visitProject(user, fusionProject1.id)
             })
 
@@ -132,7 +132,7 @@ describe('Landing page', () => {
         })
 
         context('Project evaluations (only active evaluation of selected project are listed)', () => {
-            before('', () => {
+            before('Log in as user, go to project evaluations', () => {
                 cy.visitProject(user, fusionProject1.id)
                 cy.contains('Project evaluations').click()
             })
@@ -158,10 +158,12 @@ describe('Landing page', () => {
         })
         context(`For Admin only: Listing of hidden evaluations`, () => {
             it('User with no admin role cannot see hidden evaluations', () => {
+                cy.visitProject(user, fusionProject1.id)
+                cy.contains('Project evaluations').should('exist')
                 cy.get('[role="button"').contains('Hidden evaluations').should('not.exist')
             })
             context('This context', () => {
-                before('before ', () => {
+                before('Log in as admin ', () => {
                     cy.visitProject(adminUser, fusionProject1.id)
                 })
                 evaluations.forEach(t => {
@@ -177,7 +179,7 @@ describe('Landing page', () => {
     })
 
     context('Actions', () => {
-        before('', () => {
+        before('Log in as user, go to actions table', () => {
             cy.visitProject(user, fusionProject1.id)
             cy.get('button').contains('Actions').click()
         })
@@ -212,7 +214,7 @@ describe('Landing page', () => {
     })
 
     context('Page navigation', () => {
-        beforeEach('', () => {
+        beforeEach('Log in as user', () => {
             cy.visitProject(user, fusionProject1.id)
         })
         it('User can navigate to Actions tab from Dashboard', () => {

--- a/frontend/cypress/integration/landing_page_spec.ts
+++ b/frontend/cypress/integration/landing_page_spec.ts
@@ -162,15 +162,15 @@ describe('Landing page', () => {
                 cy.contains('Project evaluations').should('exist')
                 cy.get('[role="button"').contains('Hidden evaluations').should('not.exist')
             })
-            context('This context', () => {
+            context('Hidden evaluations are listed under Hidden evaluations tab', () => {
                 before('Log in as admin ', () => {
                     cy.visitProject(adminUser, fusionProject1.id)
+                    cy.get('[role="button"').contains('Hidden evaluations').click()
                 })
                 evaluations.forEach(t => {
                     it(`Evaluation with state ${t.evaluation.status} in ${t.inProject ? 'selected' : ' different'} project (id=${
                         t.evaluation.fusionProjectId
                     }) ${t.hidden ? 'is listed' : 'is not listed '}`, () => {
-                        cy.get('[role="button"').contains('Hidden evaluations').click()
                         t.hidden ? cy.contains(t.evaluation.name).should('exist') : cy.contains(t.evaluation.name).should('not.exist')
                     })
                 })

--- a/frontend/cypress/integration/landing_page_spec.ts
+++ b/frontend/cypress/integration/landing_page_spec.ts
@@ -109,7 +109,7 @@ describe('Landing page', () => {
         beforeEach('Log in as user', () => {
             cy.visitProject(user, fusionProject1.id)
         })
-        context('My evaluations (only my evaluations are listed) regardless of status and project', () => {
+        context('My evaluations are listed regardless of status and project', () => {
             it(`All evaluations of user is listed under my evaluations - irrespective of status and project`, () => {
                 cy.get(`[data-testid=project-table]`).within(() => {
                     evaluations.forEach(t => {
@@ -181,11 +181,6 @@ describe('Landing page', () => {
                         myActiveEvaluationInProject.actions.find(a => a.assignedTo.user === user && a.isVoided === true)!.title
                     ).should('not.exist')
                     cy.contains(myActiveEvaluationInProject.actions.find(a => a.assignedTo.user !== user)!.title).should('not.exist')
-                })
-                actionTable.table().within(() => {
-                    cy.contains(
-                        myActiveEvaluationInProject.actions.find(a => a.assignedTo.user === user && a.isVoided === true)!.title
-                    ).should('not.exist')
                 })
             })
 

--- a/frontend/cypress/integration/landing_page_spec.ts
+++ b/frontend/cypress/integration/landing_page_spec.ts
@@ -97,29 +97,27 @@ describe('Landing page', () => {
         notMyHiddenEvaluationNotInProject.plant()
     })
 
+    const evaluations = [
+        { evaluation: myActiveEvaluationInProject, mine: true, inProject: true, hidden: false },
+        { evaluation: notMyActiveEvaluationInProject, mine: false, inProject: true, hidden: false },
+        { evaluation: myActiveEvaluationNotInProject, mine: true, inProject: false, hidden: false },
+        { evaluation: myHiddenEvaluationInProject, mine: true, inProject: false, hidden: true },
+        { evaluation: notMyHiddenEvaluationNotInProject, mine: false, inProject: false, hidden: true },
+    ]
+
     context(`Dashboard `, () => {
         context('My evaluations (only my evaluations are listed) regardless of status and project', () => {
             before(() => {
                 cy.visitProject(user, fusionProject1.id)
             })
-            const testdata = [
-                { evaluation: myActiveEvaluationInProject, listed: true },
-                { evaluation: notMyActiveEvaluationInProject, listed: false },
-                { evaluation: myActiveEvaluationNotInProject, listed: true },
-                { evaluation: myHiddenEvaluationInProject, listed: true },
-                { evaluation: notMyHiddenEvaluationNotInProject, listed: false },
-            ]
-            testdata.forEach(t => {
-                it(`Evaluation with state ${t.evaluation.status} in ${
-                    t.evaluation.fusionProjectId === selectedProject.id ? 'selected' : ' different'
-                } project (id=${t.evaluation.fusionProjectId}) that user ${
-                    t.evaluation.participants.find(e => e.user === user)
-                        ? 'participates in is listed'
-                        : 'does not participate in is not listed '
-                }`, () => {
+
+            evaluations.forEach(t => {
+                it(`Evaluation with state ${t.evaluation.status} in ${t.inProject ? 'selected' : ' different'} project (id=${
+                    t.evaluation.fusionProjectId
+                }) that user ${t.mine ? 'participates in is listed' : 'does not participate in is not listed '}`, () => {
                     const evalName = t.evaluation.name
                     cy.get(`[data-testid=project-table]`).within(() => {
-                        t.listed ? cy.contains(evalName).should('exist') : cy.contains(evalName).should('not.exist')
+                        t.mine ? cy.contains(evalName).should('exist') : cy.contains(evalName).should('not.exist')
                     })
                 })
             })
@@ -138,22 +136,13 @@ describe('Landing page', () => {
                 cy.visitProject(user, fusionProject1.id)
                 cy.contains('Project evaluations').click()
             })
-            const testdata = [
-                { evaluation: myActiveEvaluationInProject, listed: true },
-                { evaluation: notMyActiveEvaluationInProject, listed: true },
-                { evaluation: myActiveEvaluationNotInProject, listed: false },
-                { evaluation: myHiddenEvaluationInProject, listed: false },
-                { evaluation: notMyHiddenEvaluationNotInProject, listed: false },
-            ]
-            testdata.forEach(t => {
-                it(`Evaluation with state ${t.evaluation.status} in ${
-                    t.evaluation.fusionProjectId === selectedProject.id ? 'selected' : ' different'
-                } project (id=${t.evaluation.fusionProjectId}) with status ${t.evaluation.status} ${
-                    t.evaluation.status === Status.Voided ? 'is not listed ' : 'is listed '
-                }`, () => {
+            evaluations.forEach(t => {
+                it(`Evaluation with state ${t.evaluation.status} in ${t.inProject ? 'selected' : ' different'} project (id=${
+                    t.evaluation.fusionProjectId
+                }) with status ${t.evaluation.status} ${t.inProject ? 'is listed ' : 'is not listed '}`, () => {
                     const evalName = t.evaluation.name
                     cy.get(`[data-testid=project-table]`).within(() => {
-                        t.listed ? cy.contains(evalName).should('exist') : cy.contains(evalName).should('not.exist')
+                        t.inProject ? cy.contains(evalName).should('exist') : cy.contains(evalName).should('not.exist')
                     })
                 })
             })
@@ -175,21 +164,12 @@ describe('Landing page', () => {
                 before('before ', () => {
                     cy.visitProject(adminUser, fusionProject1.id)
                 })
-                const testdata = [
-                    { evaluation: myActiveEvaluationInProject, listed: false },
-                    { evaluation: notMyActiveEvaluationInProject, listed: false },
-                    { evaluation: myActiveEvaluationNotInProject, listed: false },
-                    { evaluation: myHiddenEvaluationInProject, listed: true },
-                    { evaluation: notMyHiddenEvaluationNotInProject, listed: true },
-                ]
-                testdata.forEach(t => {
-                    it(`Evaluation with state ${t.evaluation.status} in ${
-                        t.evaluation.fusionProjectId === selectedProject.id ? 'selected' : ' different'
-                    } project (id=${t.evaluation.fusionProjectId}) ${
-                        t.evaluation.status === Status.Voided ? 'is listed' : 'is not listed '
-                    }`, () => {
+                evaluations.forEach(t => {
+                    it(`Evaluation with state ${t.evaluation.status} in ${t.inProject ? 'selected' : ' different'} project (id=${
+                        t.evaluation.fusionProjectId
+                    }) ${t.hidden ? 'is listed' : 'is not listed '}`, () => {
                         cy.get('[role="button"').contains('Hidden evaluations').click()
-                        t.listed ? cy.contains(t.evaluation.name).should('exist') : cy.contains(t.evaluation.name).should('not.exist')
+                        t.hidden ? cy.contains(t.evaluation.name).should('exist') : cy.contains(t.evaluation.name).should('not.exist')
                     })
                 })
             })

--- a/frontend/cypress/support/testsetup/gql.ts
+++ b/frontend/cypress/support/testsetup/gql.ts
@@ -258,3 +258,11 @@ export const SET_SUMMARY = `
         }
     }
 `
+
+export const SET_EVALUATION_STATUS = `
+    mutation SetEvaluationStatus($evaluationId: String!, $newStatus: Status!) {
+        setEvaluationStatus(evaluationId: $evaluationId, newStatus: $newStatus) {
+            id
+    }
+}
+`


### PR DESCRIPTION
Refactored landing page tests and added tests for hidden (voided) evaluations.
With refactoring tests run much faster (25-30 s for 23 tests) for more tests than before (40 s for 13 tests)