### PR TITLE
New view for portfolios

### DIFF
--- a/frontend/cypress/support/mock/external/projects.ts
+++ b/frontend/cypress/support/mock/external/projects.ts
@@ -40,7 +40,26 @@ export const fusionProject6 = new FusionProject({
     name: 'Broken Coconut',
 })
 
-export const fusionProjects = [fusionProject1, fusionProject2, fusionProject3, fusionProject4, fusionProject5, fusionProject6]
+export const fusionProject7 = new FusionProject({
+    id: '1',
+    name: 'Because backend',
+})
+
+export const fusionProject8 = new FusionProject({
+    id: '2',
+    name: 'Backend made me',
+})
+
+export const fusionProjects = [
+    fusionProject1,
+    fusionProject2,
+    fusionProject3,
+    fusionProject4,
+    fusionProject5,
+    fusionProject6,
+    fusionProject7,
+    fusionProject8,
+]
 
 export function findFusionProjectByID(id: string) {
     return fusionProjects.filter(p => p.id == id)[0]

--- a/frontend/src/api/fragments.ts
+++ b/frontend/src/api/fragments.ts
@@ -40,6 +40,9 @@ export const EVALUATION_DASHBOARD_FIELDS_FRAGMENT = gql`
         progression
         createDate
         status
+        project {
+            fusionProjectId
+        }
         questions {
             id
             barrier

--- a/frontend/src/views/Project/Dashboard/Portfolios.tsx
+++ b/frontend/src/views/Project/Dashboard/Portfolios.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { EvaluationsWithPortfolio } from '../../../utils/hooks'
+import { Accordion } from '@equinor/eds-core-react'
+import EvaluationsTable from './EvaluationsTable'
+
+interface Props {
+    evaluationsWithPortfolio: EvaluationsWithPortfolio
+}
+
+const Portfolios = ({ evaluationsWithPortfolio }: Props) => {
+    return (
+        <>
+            <Accordion headerLevel="h3">
+                {Object.entries(evaluationsWithPortfolio)
+                    .reverse()
+                    .map(([portfolio, evaluations], index) => {
+                        return (
+                            <Accordion.Item key={index}>
+                                <Accordion.Header>{portfolio}</Accordion.Header>
+                                <Accordion.Panel>
+                                    <EvaluationsTable evaluations={evaluations} />
+                                </Accordion.Panel>
+                            </Accordion.Item>
+                        )
+                    })}
+            </Accordion>
+        </>
+    )
+}
+
+export default Portfolios


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1130244/140033486-1f5323ff-f023-4719-996b-246f2c57ad77.png)

The hook to get portfolios is changed to optimize loading time, and handle async calls, but the original logic for where to find portfolio is maintained. Needs to be tested because it's difficult to know if the portfolios are correct.