### PR TITLE
Initial selection of quickfact-enabled items

### DIFF
--- a/frontend/src/views/Evaluation/EvaluationView.tsx
+++ b/frontend/src/views/Evaluation/EvaluationView.tsx
@@ -1,4 +1,4 @@
-import { Step, Stepper } from '@equinor/fusion-components'
+import { ApplicationGuidanceAnchor, Step, Stepper } from '@equinor/fusion-components'
 import React from 'react'
 import { Evaluation, Progression, Role } from '../../api/models'
 import { calcProgressionStatus } from '../../utils/ProgressionStatus'

--- a/frontend/src/views/Evaluation/Nomination/AddNomineeDialog.tsx
+++ b/frontend/src/views/Evaluation/Nomination/AddNomineeDialog.tsx
@@ -1,6 +1,14 @@
 import React from 'react'
 import { useApiClients, PersonDetails } from '@equinor/fusion'
-import { PersonCard, Button, SearchableDropdown, SearchableDropdownOption, Spinner, ModalSideSheet } from '@equinor/fusion-components'
+import {
+    PersonCard,
+    Button,
+    SearchableDropdown,
+    SearchableDropdownOption,
+    Spinner,
+    ModalSideSheet,
+    ApplicationGuidanceAnchor,
+} from '@equinor/fusion-components'
 
 import { Organization, Role, Participant } from '../../../api/models'
 import { useEffect } from 'react'

--- a/frontend/src/views/Evaluation/Nomination/NominationView.tsx
+++ b/frontend/src/views/Evaluation/Nomination/NominationView.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { ApolloError, gql, useMutation, useQuery } from '@apollo/client'
 
 import { Box } from '@material-ui/core'
-import { TextArea } from '@equinor/fusion-components'
+import { ApplicationGuidanceAnchor, TextArea } from '@equinor/fusion-components'
 import { Button, Icon, Tooltip } from '@equinor/eds-core-react'
 import { visibility, visibility_off } from '@equinor/eds-icons'
 import { useCurrentUser } from '@equinor/fusion'
@@ -103,7 +103,7 @@ const NominationView = ({ evaluation, onNextStep }: NominationViewProps) => {
                         {evaluation.name}
                     </h2>
                     {(participantCanHideEvaluation(participant) || isAdmin) && (
-                        <>
+                        <ApplicationGuidanceAnchor anchor={'nomination-view-hide-from-list'} scope="bmt">
                             <Tooltip title={isVisible ? 'Visible in list' : 'Hidden from list'} placement="bottom">
                                 <Icon data={isVisible ? visibility : visibility_off} style={{ marginRight: '10px' }}></Icon>
                             </Tooltip>
@@ -114,16 +114,18 @@ const NominationView = ({ evaluation, onNextStep }: NominationViewProps) => {
                             >
                                 {isVisible ? 'Hide from list' : 'Make visible'}
                             </Button>
-                        </>
+                        </ApplicationGuidanceAnchor>
                     )}
                 </Box>
                 {participantCanProgressEvaluation(participant) && (
                     <Box display={'flex'} alignItems={'center'}>
                         <SaveIndicator savingState={statusSavingState} />
                         <Box ml={2}>
-                            <Button onClick={onNextStepClick} disabled={disableProgression(evaluation, participant, viewProgression)}>
-                                Finish Nomination
-                            </Button>
+                            <ApplicationGuidanceAnchor anchor={'nomination-view-finish-nomination-button'} scope="bmt">
+                                <Button onClick={onNextStepClick} disabled={disableProgression(evaluation, participant, viewProgression)}>
+                                    Finish Nomination
+                                </Button>
+                            </ApplicationGuidanceAnchor>
                         </Box>
                     </Box>
                 )}

--- a/frontend/src/views/Project/Dashboard/CreateEvaluationDialog.tsx
+++ b/frontend/src/views/Project/Dashboard/CreateEvaluationDialog.tsx
@@ -1,13 +1,7 @@
 import React, { useState } from 'react'
 import { ApolloError, gql, useQuery } from '@apollo/client'
 
-import {
-    Button,
-    ModalSideSheet,
-    SearchableDropdown,
-    SearchableDropdownOption,
-    TextArea,
-} from '@equinor/fusion-components'
+import { Button, ModalSideSheet, SearchableDropdown, SearchableDropdownOption, TextArea } from '@equinor/fusion-components'
 import { TextField, Typography } from '@equinor/eds-core-react'
 import { Container, Grid } from '@material-ui/core'
 import { useProject } from '../../../globals/contexts'
@@ -20,21 +14,13 @@ interface CreateEvaluationDialogProps {
     onCancelClick: () => void
 }
 
-const CreateEvaluationDialog = ({
-    open,
-    onCreate,
-    onCancelClick,
-}: CreateEvaluationDialogProps) => {
+const CreateEvaluationDialog = ({ open, onCreate, onCancelClick }: CreateEvaluationDialogProps) => {
     const project = useProject()
     const [nameInputValue, setNameInputValue] = useState<string>('')
     const [inputErrorMessage, setInputErrorMessage] = useState<string>('')
-    const [selectedEvaluation, setSelectedEvaluation] = useState<
-        string | undefined
-    >(undefined)
+    const [selectedEvaluation, setSelectedEvaluation] = useState<string | undefined>(undefined)
 
-    const [selectedProjectCategory, setSelectedProjectCategory] = useState<
-        string | undefined
-    >(undefined)
+    const [selectedProjectCategory, setSelectedProjectCategory] = useState<string | undefined>(undefined)
 
     const handleCreateClick = () => {
         if (nameInputValue.length <= 0) {
@@ -51,17 +37,9 @@ const CreateEvaluationDialog = ({
         setNameInputValue(name)
     }
 
-    const {
-        loading: loadingEvaluationQuery,
-        evaluations,
-        error: errorEvaluationQuery,
-    } = useGetAllEvaluationsQuery(project.id)
+    const { loading: loadingEvaluationQuery, evaluations, error: errorEvaluationQuery } = useGetAllEvaluationsQuery(project.id)
 
-    const {
-        loading: loadingProjectCategoryQuery,
-        projectCategories,
-        error: errorProjectCategoryQuery,
-    } = useGetAllProjectCategoriesQuery()
+    const { loading: loadingProjectCategoryQuery, projectCategories, error: errorProjectCategoryQuery } = useGetAllProjectCategoriesQuery()
 
     if (loadingEvaluationQuery || loadingProjectCategoryQuery) {
         return <>Loading...</>
@@ -70,10 +48,7 @@ const CreateEvaluationDialog = ({
     if (errorEvaluationQuery !== undefined || evaluations === undefined) {
         return (
             <div>
-                <TextArea
-                    value={apiErrorMessage('Could not load evaluations')}
-                    onChange={() => {}}
-                />
+                <TextArea value={apiErrorMessage('Could not load evaluations')} onChange={() => {}} />
             </div>
         )
     }
@@ -81,30 +56,22 @@ const CreateEvaluationDialog = ({
     if (errorProjectCategoryQuery !== undefined || projectCategories === undefined) {
         return (
             <div>
-                <TextArea
-                    value={apiErrorMessage('Could not load Project Categorie')}
-                    onChange={() => {}}
-                />
+                <TextArea value={apiErrorMessage('Could not load Project Categorie')} onChange={() => {}} />
             </div>
         )
     }
 
-    const projectCategoryOptions: SearchableDropdownOption[] = projectCategories.map(
-        (projectCategory: ProjectCategory) => ({
-            title: projectCategory.name,
-            key: projectCategory.id,
-            isSelected: projectCategory.id == selectedProjectCategory,
-        })
+    const projectCategoryOptions: SearchableDropdownOption[] = projectCategories.map((projectCategory: ProjectCategory) => ({
+        title: projectCategory.name,
+        key: projectCategory.id,
+        isSelected: projectCategory.id == selectedProjectCategory,
+    }))
 
-    )
-
-    const evaluationOptions: SearchableDropdownOption[] = evaluations.map(
-        (evaluation: Evaluation) => ({
-            title: evaluation.name,
-            key: evaluation.id,
-            isSelected: evaluation.id === selectedEvaluation,
-        })
-    )
+    const evaluationOptions: SearchableDropdownOption[] = evaluations.map((evaluation: Evaluation) => ({
+        title: evaluation.name,
+        key: evaluation.id,
+        isSelected: evaluation.id === selectedEvaluation,
+    }))
 
     return (
         <>
@@ -136,9 +103,7 @@ const CreateEvaluationDialog = ({
                             <SearchableDropdown
                                 label="Project Category"
                                 placeholder="Select Project Category"
-                                onSelect={option =>
-                                    setSelectedProjectCategory(option.key)
-                                }
+                                onSelect={option => setSelectedProjectCategory(option.key)}
                                 options={projectCategoryOptions}
                             />
                         </Grid>
@@ -146,9 +111,7 @@ const CreateEvaluationDialog = ({
                             <SearchableDropdown
                                 label="Previous Evaluation (Optional)"
                                 placeholder="Select previous evaluation"
-                                onSelect={option =>
-                                    setSelectedEvaluation(option.key)
-                                }
+                                onSelect={option => setSelectedEvaluation(option.key)}
                                 options={evaluationOptions}
                             />
                         </Grid>
@@ -177,7 +140,7 @@ interface EvaluationsQueryProps {
 
 const useGetAllEvaluationsQuery = (projectId: string): EvaluationsQueryProps => {
     const GET_EVALUATIONS = gql`
-        query($projectId: String!) {
+        query ($projectId: String!) {
             evaluations(where: { project: { id: { eq: $projectId } } }) {
                 id
                 name
@@ -185,10 +148,7 @@ const useGetAllEvaluationsQuery = (projectId: string): EvaluationsQueryProps => 
         }
     `
 
-    const { loading, data, error } = useQuery<{ evaluations: Evaluation[] }>(
-        GET_EVALUATIONS,
-        { variables: { projectId } }
-    )
+    const { loading, data, error } = useQuery<{ evaluations: Evaluation[] }>(GET_EVALUATIONS, { variables: { projectId } })
 
     return {
         loading,
@@ -212,9 +172,7 @@ const useGetAllProjectCategoriesQuery = (): ProjectCategoriesQueryProps => {
             }
         }
     `
-    const { loading, data, error } = useQuery<{ projectCategory: ProjectCategory[] }>(
-        GET_PROJECT_CATEGORY
-    )
+    const { loading, data, error } = useQuery<{ projectCategory: ProjectCategory[] }>(GET_PROJECT_CATEGORY)
 
     return {
         loading,

--- a/frontend/src/views/Project/Dashboard/EvaluationsTable.tsx
+++ b/frontend/src/views/Project/Dashboard/EvaluationsTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Icon, Table, Tooltip, Typography } from '@equinor/eds-core-react'
 import { warning_filled } from '@equinor/eds-icons'
+import { ApplicationGuidanceAnchor } from '@equinor/fusion-components'
 import { Evaluation, Progression } from '../../../api/models'
 import ProgressStatusIcon from '../../../components/ProgressStatusIcon'
 import { Link } from 'react-router-dom'

--- a/frontend/src/views/Project/Dashboard/ProjectDashboardView.tsx
+++ b/frontend/src/views/Project/Dashboard/ProjectDashboardView.tsx
@@ -4,6 +4,7 @@ import { ApolloError, gql, useQuery } from '@apollo/client'
 import { Box } from '@material-ui/core'
 import { TextArea } from '@equinor/fusion-components'
 import { useCurrentUser } from '@equinor/fusion'
+import { ApplicationGuidanceAnchor } from '@equinor/fusion-components'
 
 import { Evaluation, Project, Status } from '../../../api/models'
 import CreateEvaluationButton from './CreateEvaluationButton'
@@ -140,7 +141,9 @@ const ProjectDashboardView = ({ project }: Props) => {
 
     return (
         <div style={{ margin: 20 }}>
-            <CreateEvaluationButton projectId={project.id} />
+            <ApplicationGuidanceAnchor anchor={'dashboard-create-evaluations-button'} scope="bmt">
+                <CreateEvaluationButton projectId={project.id} />
+            </ApplicationGuidanceAnchor>
             <Box marginY={2}>
                 <Typography variant="h2">Evaluations</Typography>
             </Box>
@@ -150,13 +153,14 @@ const ProjectDashboardView = ({ project }: Props) => {
                         return undefined
                     } else {
                         return (
-                            <StyledChip
-                                key={value}
-                                variant={selectedProjectTable === value ? 'active' : 'default'}
-                                onClick={() => setSelectedProjectTable(value)}
-                            >
-                                {mapTableSelectionToText(value)}
-                            </StyledChip>
+                            <ApplicationGuidanceAnchor anchor={'dashboard-evaluations-filter-' + value} scope="bmt" key={value}>
+                                <StyledChip
+                                    variant={selectedProjectTable === value ? 'active' : 'default'}
+                                    onClick={() => setSelectedProjectTable(value)}
+                                >
+                                    {mapTableSelectionToText(value)}
+                                </StyledChip>
+                            </ApplicationGuidanceAnchor>
                         )
                     }
                 })}

--- a/frontend/src/views/Project/ProjectRoute.tsx
+++ b/frontend/src/views/Project/ProjectRoute.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { ApolloError, gql, useQuery } from '@apollo/client'
 
 import { RouteComponentProps } from 'react-router-dom'
-import { TextArea } from '@equinor/fusion-components'
+import { ApplicationGuidanceAnchor, TextArea } from '@equinor/fusion-components'
 import { Tabs } from '@equinor/eds-core-react'
 import { useCurrentUser } from '@equinor/fusion'
 
@@ -45,9 +45,19 @@ const ProjectRoute = ({ match }: RouteComponentProps<Params>) => {
         <ProjectContext.Provider value={project}>
             <Tabs activeTab={activeTab} onChange={setActiveTab}>
                 <List>
-                    <Tab>Dashboard</Tab>
-                    <Tab>Actions</Tab>
-                    {isAdmin ? <Tab>Admin</Tab> : <></>}
+                    <ApplicationGuidanceAnchor anchor={'dashboard-tabs-dashboard'} scope="bmt">
+                        <Tab>Dashboard</Tab>
+                    </ApplicationGuidanceAnchor>
+                    <ApplicationGuidanceAnchor anchor={'dashboard-tabs-actions'} scope="bmt">
+                        <Tab>Actions</Tab>
+                    </ApplicationGuidanceAnchor>
+                    {isAdmin ? (
+                        <ApplicationGuidanceAnchor anchor={'dashboard-tabs-admin'} scope="bmt">
+                            <Tab>Admin</Tab>
+                        </ApplicationGuidanceAnchor>
+                    ) : (
+                        <></>
+                    )}
                 </List>
                 <Panels>
                     <StyledTabPanel>


### PR DESCRIPTION
Inital suggestion to which elements it should be possible to comment on, on the following pages:

* Dashboard - evaluations list
* Create Evaluation View
* Nomination view

I have wrapped the elements I would have pointed to if I were to explain the application to somebody new, and omitted every button and text field that felt self-explanatory (i.e. finish nomination). However, if a button is self explanatory, but it seems uncertain what will happen after the action is performed, I have aimed to also wrap these elements.

