### PR TITLE
Adding branch to template for radix trigger

### DIFF
--- a/pipelines/ArtifactBuild.yml
+++ b/pipelines/ArtifactBuild.yml
@@ -145,6 +145,7 @@ stages:
           radixToken: $(RadixToken)
           buildId: $(Build.BuildId)
           envshortname: CI
+          branch: master
 
     - template: templates/stage-deploy-approval.yml
       parameters:
@@ -176,6 +177,7 @@ stages:
           radixToken: $(RadixToken)
           buildId: $(Build.BuildId)
           envshortname: QA
+          branch: qa
 
     - template: templates/stage-deploy-approval.yml
       parameters:
@@ -207,3 +209,4 @@ stages:
           radixToken: $(RadixToken)
           buildId: $(Build.BuildId)
           envshortname: Production
+          branch: prod

--- a/pipelines/templates/stage-trigger-radix.yml
+++ b/pipelines/templates/stage-trigger-radix.yml
@@ -1,9 +1,9 @@
 parameters:
     - name: name # defaults for any parameters that aren't specified
-      default: ""
     - name: radixToken
     - name: buildId
     - name: envshortname
+    - name: branch
 
 stages:
     - stage: ${{ parameters.name }}
@@ -26,7 +26,7 @@ stages:
                           "Content-Type":"application/json",
                           "Authorization": "Bearer ${{ parameters.radixToken }}"
                           }
-                      body: '{"branch": "master",  "triggeredBy": "${{ parameters.buildId }}"}'
+                      body: '{"branch": "${{ parameters.branch }}",  "triggeredBy": "${{ parameters.buildId }}-${{ parameters.branch }}"}'
                       urlSuffix: "api/v1/applications/fusion-bmt/pipelines/build-deploy"
                       waitForCompletion: "false"
                       successCriteria: eq(root['status'], 'Waiting')


### PR DESCRIPTION
To avoid identical id for the deployment step and to ensure radix builds
correct environment we send in branch as parameter. #869