### PR TITLE
Added url rendring and icon to add url syntax to input field on closi…

### DIFF
--- a/frontend/cypress/page_objects/action.ts
+++ b/frontend/cypress/page_objects/action.ts
@@ -106,7 +106,7 @@ export class EditActionDialog extends ActionDialog {
             .should('contain.text', note.createdBy.user.name + ' closed action')
             .within(() => {
                 if (note.text) {
-                    cy.getByDataTestid('note_text').should('have.text', note.text)
+                    cy.getByDataTestid('note_text').should('contain.text', note.text)
                 }
             })
     }

--- a/frontend/src/components/Action/EditForm/ActionEditForm.tsx
+++ b/frontend/src/components/Action/EditForm/ActionEditForm.tsx
@@ -10,12 +10,25 @@ import { Action, Participant, Priority, Question } from '../../../api/models'
 import { barrierToString } from '../../../utils/EnumToString'
 import { useEffectNotOnMount } from '../../../utils/hooks'
 import { checkIfParticipantValid, checkIfTitleValid, ErrorIcon, TextFieldChangeEvent, Validity } from '../utils'
-import { check_circle_outlined } from '@equinor/eds-icons'
+import { check_circle_outlined, link } from '@equinor/eds-icons'
 import { updateValidity } from '../../../views/helpers'
+import { tokens } from '@equinor/eds-tokens'
 
 const StyledDate = styled(Typography)`
     float: right;
     margin-top: 10px;
+`
+
+const LinkIcon = styled(Icon)`
+    position: absolute;
+    right: 15px;
+    top: -3px;
+    cursor: pointer;
+    color: ${tokens.colors.text.static_icons__secondary.rgba};
+
+    &:hover {
+        color: ${tokens.colors.text.static_icons__default.rgba};
+    }
 `
 
 interface Props {
@@ -139,6 +152,10 @@ const ActionEditForm = ({
         }
     }, [isClosingRemarkSaved])
 
+    const addLink = () => {
+        setCompletingReason(completingReason + '[text](url)')
+    }
+
     return (
         <>
             <Grid container spacing={3}>
@@ -254,7 +271,8 @@ const ActionEditForm = ({
                             <Typography variant="h5">Are you sure you want to close the action?</Typography>
                             <Typography variant="body_short">This cannot be undone.</Typography>
                         </Grid>
-                        <Grid item xs={12}>
+                        <Grid item xs={12} style={{ position: 'relative' }}>
+                            <LinkIcon data={link} onClick={addLink} />
                             <TextField
                                 id="completed-reason"
                                 value={completingReason}

--- a/frontend/src/components/Action/EditForm/NotesAndClosingRemarksList.tsx
+++ b/frontend/src/components/Action/EditForm/NotesAndClosingRemarksList.tsx
@@ -3,6 +3,7 @@ import { Box } from '@material-ui/core'
 import { ClosingRemark, Note } from '../../../api/models'
 import { PersonDetails } from '@equinor/fusion'
 import { tokens } from '@equinor/eds-tokens'
+import { MarkdownViewer } from '@equinor/fusion-components'
 
 interface Props {
     notesAndClosingRemarks: (Note | ClosingRemark)[]
@@ -58,8 +59,8 @@ const NotesAndClosingRemarksList = ({ notesAndClosingRemarks, participantsDetail
                                 {hoursPadded}:{minutesPadded} - {dateString}
                             </Box>
                         </Box>
-                        <Box mt={1} data-testid={'note_text'}>
-                            {noteOrRemark.text}
+                        <Box data-testid={'note_text'}>
+                            <MarkdownViewer markdown={noteOrRemark.text} />
                         </Box>
                     </Box>
                 )


### PR DESCRIPTION
…ng comment

There has been a request that it should be possible to add a hyperlink when closing an action. With this PR, a url-button is added close to the closing-reason input field. When clicking this, the reason-field will get the following syntax added: [text](url), so that they can insert the link with the right syntax:

![image](https://user-images.githubusercontent.com/1130244/142168588-17b32430-4e87-4d75-b260-ca1b0e919639.png)

Also changed the rendering of comments so that the link will be rendered as a link. This also works for notes now, but the note field doesn't have the link-button as of now, since that was not part of the assignment. It is however possible to use the same syntax to write a link there as well.

For some reason, the `<MarkdownViewer>` added a \n to the comment when fetched from the UI, so the test had to be slightly modified to accommodate this.