### PR TITLE
Made some changes to the CreateEvaluationDialog-view, to comply with the way the UI looks and acts in the rest of the application.

### DIFF
--- a/frontend/cypress/page_objects/project.ts
+++ b/frontend/cypress/page_objects/project.ts
@@ -19,7 +19,7 @@ export default class ProjectPage {
         }
 
         previousEvaluation = () => {
-            return cy.contains('Previous Evaluation').parent()
+            return cy.contains('Previous evaluation').parent()
         }
 
         projectCategoryTextField = () => {

--- a/frontend/src/components/ErrorBanner.tsx
+++ b/frontend/src/components/ErrorBanner.tsx
@@ -1,0 +1,26 @@
+import { Banner, Button, Icon } from '@equinor/eds-core-react'
+import { error_filled } from '@equinor/eds-icons'
+import React from 'react'
+
+interface Props {
+    message: string
+    onClose: () => void
+}
+
+const ErrorBanner = ({ message, onClose }: Props) => {
+    return (
+        <Banner style={{ backgroundColor: 'pink' }}>
+            <Banner.Icon variant="warning">
+                <Icon data={error_filled}></Icon>
+            </Banner.Icon>
+            <Banner.Message>{message}</Banner.Message>
+            <Banner.Actions>
+                <Button color="secondary" onClick={onClose}>
+                    Close
+                </Button>
+            </Banner.Actions>
+        </Banner>
+    )
+}
+
+export default ErrorBanner

--- a/frontend/src/utils/hooks.ts
+++ b/frontend/src/utils/hooks.ts
@@ -186,6 +186,10 @@ export const useFilter = <Type>() => {
     return { filter, onFilterToggled }
 }
 
+/*
+ * Checks if the provided value is valid according to the provided validityCheck and returns a Validity object.
+ * Updates the Validity every time the value changes.
+ */
 export const useValidityCheck = <Type>(value: Type, isValid: () => boolean) => {
     const [valueValidity, setValueValidity] = useState<Validity>('default')
 

--- a/frontend/src/views/Project/Dashboard/DashboardView.tsx
+++ b/frontend/src/views/Project/Dashboard/DashboardView.tsx
@@ -159,7 +159,9 @@ const DashboardView = ({ project }: Props) => {
             )}
             {portfoliosSelected && (
                 <>
-                    {allActiveEvaluationsWithProjectMasterAndPortfolio && <Portfolios evaluationsWithProjectMasterAndPortfolio={allActiveEvaluationsWithProjectMasterAndPortfolio} />}
+                    {allActiveEvaluationsWithProjectMasterAndPortfolio && (
+                        <Portfolios evaluationsWithProjectMasterAndPortfolio={allActiveEvaluationsWithProjectMasterAndPortfolio} />
+                    )}
                     {(loadingActiveEvaluations || !allActiveEvaluationsWithProjectMasterAndPortfolio) && <CenteredCircularProgress />}
                     {errorActiveEvaluations !== undefined && errorMessage}
                 </>


### PR DESCRIPTION
- Started to use a new error display for errors in smaller views: ` <ErrorBanner/>`. This will be instead of the grey text fields we have been using until now:

Earlier:
![image](https://user-images.githubusercontent.com/1130244/143223606-c1ae745a-36ec-44a8-b47a-4a2866a5d601.png)

Now:
![image](https://user-images.githubusercontent.com/1130244/143223687-1b0e8207-1fc3-487c-b4d9-429d1fb40fda.png)

- The error display is also moved. Earlier, if creating an evaluation didn't succeed, the sidebar would close, and the old error display would replace the "Create Evaluation"-button on the Dashboard. Now, the error banner will appear in the sidebar, making it possible to try again without losing the typed data. 

Earlier:
![image](https://user-images.githubusercontent.com/1130244/143225175-a120d189-f87d-4337-b4b6-8c3f6630a959.png)

Now:
![image](https://user-images.githubusercontent.com/1130244/143224239-58a746fd-183a-4689-a22c-1c44e5f6424c.png)

- Removed the text explaining that it's difficult to remove a created evaluation, since we now have the possibility to hide an evaluation.

![image](https://user-images.githubusercontent.com/1130244/143224430-c677e234-e603-4ae2-8878-7adfe7ad8de8.png)

- Started using the same validation as in other forms in the application. I.e. warning message in the Input-component, instead of a free text next to the save-button. We are also using a hook to update validation status, so that we don't have to duplicate code.

Earlier:
![image](https://user-images.githubusercontent.com/1130244/143224736-1c6ae303-51ed-49e2-a573-052e528adc6c.png)

Now:
![image](https://user-images.githubusercontent.com/1130244/143224664-2381a7f5-aa39-47cc-8e9b-f0eb490adb83.png)

- Inserted cancel-button in the view

- Moved both buttons to the right, like we have most places

- Create-button is now disabled when required fields are not filled out

- (Required) behind the label on the required fields