### PR TITLE
Bugfix: Bowtie now also renders on finished evaluations

### DIFF
--- a/frontend/src/views/Project/Dashboard/Components/EvaluationsTable.tsx
+++ b/frontend/src/views/Project/Dashboard/Components/EvaluationsTable.tsx
@@ -81,9 +81,14 @@ const EvaluationsTable = ({ evaluations }: Props) => {
 
     const renderRow = (evaluation: Evaluation, index: number) => {
         const project = useProject()
-        const isWorkshopOrFollowUp = evaluation.progression === Progression.Workshop || evaluation.progression === Progression.FollowUp
-        const showBowtieContent = evaluation.questions && isWorkshopOrFollowUp
-        const answersWithBarrier = showBowtieContent ? assignAnswerToBarrierQuestions(evaluation.questions, evaluation.progression) : []
+        const isWorkshopOrLater =
+            evaluation.progression === Progression.Workshop ||
+            evaluation.progression === Progression.FollowUp ||
+            evaluation.progression === Progression.Finished
+        const showBowtieContent = evaluation.questions && isWorkshopOrLater
+        const answersWithBarrier = showBowtieContent
+            ? assignAnswerToBarrierQuestions(evaluation.questions, Progression.Finished ? Progression.FollowUp : evaluation.progression)
+            : []
         const actionsByState = getEvaluationActionsByState(evaluation)
 
         return (


### PR DESCRIPTION
**Problem**: The bowtie seemingly didn't render any "dots" if all the dots were green

**The real problem:** The evaluation with only green dots was finished, and we didn't take finished evaluations into account when we made the bowtie, because the concept didn't exist yet. Thus, we said to only render the bowtie on the progressions Workshop and FollowUp. 

**The solution:** We now render bowtie on Workshop and FollowUp and Finished, and select the questions from FollowUp when finished.