### PR TITLE
Removed outer scrollbar in questionnaire

### DIFF
--- a/frontend/src/views/Evaluation/FollowUp/Views/Questionaire/FollowUpView.tsx
+++ b/frontend/src/views/Evaluation/FollowUp/Views/Questionaire/FollowUpView.tsx
@@ -95,6 +95,7 @@ const FollowUpView = ({ evaluation, onNextStepClick }: FollowUpViewProps) => {
     const boxPadding = 20
     const boxPaddingTopPlusBottom = boxPadding * 2
     const tabsPanelPadding = 16
+    const extraPixelToAvoidScrollbar = 1
 
     return (
         <>
@@ -113,7 +114,9 @@ const FollowUpView = ({ evaluation, onNextStepClick }: FollowUpViewProps) => {
                         onScroll(selectedQuestion, tablistPositionBottom, barrierQuestions, onQuestionSummarySelected)
                     }}
                     style={{
-                        height: `calc(100vh - ${tablistPositionBottom + boxPaddingTopPlusBottom + tabsPanelPadding}px)`,
+                        height: `calc(100vh - ${
+                            tablistPositionBottom + boxPaddingTopPlusBottom + tabsPanelPadding + extraPixelToAvoidScrollbar
+                        }px)`,
                         overflow: 'scroll',
                     }}
                 >

--- a/frontend/src/views/Evaluation/Preparation/PreparationView.tsx
+++ b/frontend/src/views/Evaluation/Preparation/PreparationView.tsx
@@ -110,6 +110,7 @@ const PreparationView = ({ evaluation, onNextStepClick, onProgressParticipant }:
     const boxPadding = 20
     const boxPaddingTopPlusBottom = boxPadding * 2
     const tabsPanelPadding = 16
+    const extraPixelToAvoidScrollbar = 1
 
     return (
         <>
@@ -129,7 +130,9 @@ const PreparationView = ({ evaluation, onNextStepClick, onProgressParticipant }:
                         onScroll(selectedQuestion, tablistPositionBottom, barrierQuestions, onQuestionSummarySelected)
                     }}
                     style={{
-                        height: `calc(100vh - ${tablistPositionBottom + boxPaddingTopPlusBottom + tabsPanelPadding}px)`,
+                        height: `calc(100vh - ${
+                            tablistPositionBottom + boxPaddingTopPlusBottom + tabsPanelPadding + extraPixelToAvoidScrollbar
+                        }px)`,
                         overflow: 'scroll',
                     }}
                 >

--- a/frontend/src/views/Evaluation/Workshop/Questionaire/WorkshopView.tsx
+++ b/frontend/src/views/Evaluation/Workshop/Questionaire/WorkshopView.tsx
@@ -109,6 +109,7 @@ const WorkshopView = ({ evaluation, onNextStepClick, onProgressParticipant }: Wo
     const boxPadding = 20
     const boxPaddingTopPlusBottom = boxPadding * 2
     const tabsPanelPadding = 16
+    const extraPixelToAvoidScrollbar = 1
 
     return (
         <>
@@ -128,7 +129,9 @@ const WorkshopView = ({ evaluation, onNextStepClick, onProgressParticipant }: Wo
                         onScroll(selectedQuestion, tablistPositionBottom, barrierQuestions, onQuestionSummarySelected)
                     }}
                     style={{
-                        height: `calc(100vh - ${tablistPositionBottom + boxPaddingTopPlusBottom + tabsPanelPadding}px)`,
+                        height: `calc(100vh - ${
+                            tablistPositionBottom + boxPaddingTopPlusBottom + tabsPanelPadding + extraPixelToAvoidScrollbar
+                        }px)`,
                         overflow: 'scroll',
                     }}
                 >


### PR DESCRIPTION
To avoid the outer scrollbar, the inner div is set to a height that needs to be precisely the height of the view. This is calculated by fetching the heights and margins of some of the view elements, but for some reason the scroll bar got smaller, but didn't disappear. In this PR I simply added one pixel to the height, which made it finally disappear.

Before:
![image](https://user-images.githubusercontent.com/1130244/148057557-d146b97a-a750-4902-9529-2ff1f4d9692a.png)

After: 
![image](https://user-images.githubusercontent.com/1130244/148058049-e4a57bf4-01ba-40e4-ac62-226b2afd80b1.png)

Could be smart to pull this down to test, in case it only works on my machine.