### PR TITLE
Bug/998 admin module login disapeared

### DIFF
--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -1,6 +1,25 @@
 import { Context } from '@equinor/fusion'
 import { Question, Progression, Role, Severity, Participant } from '../api/models'
 import { SeverityCount } from './Severity'
+import jwtDecode from 'jwt-decode'
+
+interface Token {
+    [key: string]: any
+}
+
+const CACHE_ENTRY = 'FUSION_AUTH_CACHE'
+
+export const getCachedRoles = (): string[] => {
+    const fusionStorageJson: string | null = localStorage.getItem(CACHE_ENTRY)
+    if (fusionStorageJson === null) {
+        throw new Error('Could not find auth token in local storage')
+    }
+    const fusionStorage = JSON.parse(fusionStorageJson)
+    const token: string = fusionStorage[`${CACHE_ENTRY}:8829d4ca-93e8-499a-8ce1-bc0ef4840176:TOKEN`]
+    const objectFromDecodedToken: Token = jwtDecode(token) as Token
+    const roles: string[] = objectFromDecodedToken["roles"]
+    return roles
+} 
 
 export const findCorrectAnswer = (
     question: Question,

--- a/frontend/src/views/Evaluation/Nomination/NominationView.tsx
+++ b/frontend/src/views/Evaluation/Nomination/NominationView.tsx
@@ -22,6 +22,7 @@ import { genericErrorMessage, SavingState } from '../../../utils/Variables'
 import { useEffectNotOnMount, useShowErrorHook } from '../../../utils/hooks'
 import { centered } from '../../../utils/styles'
 import ErrorBanner from '../../../components/ErrorBanner'
+import { getCachedRoles } from '../../../utils/helpers'
 
 interface NominationViewProps {
     evaluation: Evaluation
@@ -41,7 +42,7 @@ const NominationView = ({ evaluation, onNextStep }: NominationViewProps) => {
     const { showErrorMessage, setShowErrorMessage } = useShowErrorHook(error)
 
     const viewProgression = Progression.Nomination
-    const isAdmin = currentUser && currentUser.roles.includes('Role.Admin')
+    const isAdmin = currentUser && getCachedRoles().includes('Role.Admin')
 
     useEffectNotOnMount(() => {
         if (loading) {

--- a/frontend/src/views/Project/Dashboard/DashboardView.tsx
+++ b/frontend/src/views/Project/Dashboard/DashboardView.tsx
@@ -5,6 +5,7 @@ import { Box } from '@material-ui/core'
 import { Chip, CircularProgress, Typography } from '@equinor/eds-core-react'
 import { ApplicationGuidanceAnchor, ErrorMessage } from '@equinor/fusion-components'
 import { useCurrentUser } from '@equinor/fusion'
+import { getCachedRoles } from '../../../utils/helpers'
 
 import { genericErrorMessage } from '../../../utils/Variables'
 import { Evaluation, Project, Status } from '../../../api/models'
@@ -70,7 +71,7 @@ const DashboardView = ({ project }: Props) => {
     }
 
     const [selectedProjectTable, setSelectedProjectTable] = React.useState<string>(TableSelection.Project)
-    const userIsAdmin = currentUser && currentUser.roles.includes('Role.Admin')
+    const userIsAdmin = currentUser && getCachedRoles().includes('Role.Admin')
     const myEvaluationsSelected = selectedProjectTable === TableSelection.User
     const projectEvaluationsSelected = selectedProjectTable === TableSelection.Project
     const hiddenEvaluationsSelected = selectedProjectTable === TableSelection.Hidden

--- a/frontend/src/views/Project/ProjectTabs.tsx
+++ b/frontend/src/views/Project/ProjectTabs.tsx
@@ -4,7 +4,7 @@ import { ApolloError, gql, useQuery } from '@apollo/client'
 import { RouteComponentProps } from 'react-router-dom'
 import { ErrorMessage } from '@equinor/fusion-components'
 import { Tabs } from '@equinor/eds-core-react'
-import { useCurrentUser } from '@equinor/fusion'
+import { registerApp, ContextTypes, Context, useAppConfig, useFusionContext, useCurrentUser } from '@equinor/fusion'
 
 import { Project } from '../../api/models'
 import { ProjectContext } from '../../globals/contexts'
@@ -27,6 +27,10 @@ const ProjectTabs = ({ match }: RouteComponentProps<Params>) => {
     const [activeTab, setActiveTab] = React.useState(0)
     const { loading, project, error } = useProjectQuery(fusionProjectId)
 
+
+    const currentUserRoles = useFusionContext().auth.container.getCachedUser()?.roles
+    console.log("User has roles:")
+    console.log(currentUserRoles)
     const isAdmin = currentUser && currentUser.roles.includes('Role.Admin')
 
     if (loading) {

--- a/frontend/src/views/Project/ProjectTabs.tsx
+++ b/frontend/src/views/Project/ProjectTabs.tsx
@@ -4,7 +4,7 @@ import { ApolloError, gql, useQuery } from '@apollo/client'
 import { RouteComponentProps } from 'react-router-dom'
 import { ErrorMessage } from '@equinor/fusion-components'
 import { Tabs } from '@equinor/eds-core-react'
-import { registerApp, ContextTypes, Context, useAppConfig, useFusionContext, useCurrentUser } from '@equinor/fusion'
+import { useCurrentUser } from '@equinor/fusion'
 
 import { Project } from '../../api/models'
 import { ProjectContext } from '../../globals/contexts'
@@ -13,6 +13,7 @@ import ActionsView from './Actions/ActionsView'
 import AdminView from './Admin/AdminView'
 import DashboardView from './Dashboard/DashboardView'
 import { genericErrorMessage } from '../../utils/Variables'
+import { getCachedRoles } from '../../utils/helpers'
 
 const { List, Tab, Panels } = Tabs
 
@@ -21,17 +22,14 @@ interface Params {
 }
 
 const ProjectTabs = ({ match }: RouteComponentProps<Params>) => {
+
     const currentUser = useCurrentUser()
     const fusionProjectId = match.params.fusionProjectId
 
     const [activeTab, setActiveTab] = React.useState(0)
     const { loading, project, error } = useProjectQuery(fusionProjectId)
 
-
-    const currentUserRoles = useFusionContext().auth.container.getCachedUser()?.roles
-    console.log("User has roles:")
-    console.log(currentUserRoles)
-    const isAdmin = currentUser && currentUser.roles.includes('Role.Admin')
+    const isAdmin = currentUser && getCachedRoles().includes('Role.Admin')
 
     if (loading) {
         return <>Loading...</>


### PR DESCRIPTION
Reason for case:
- A bug was reported, where users of BMT within Fusion with the role "Administrator" were not able to see Administrator specific tabs. 

Thinking process:
- The {User} object which the code compared on ( user.roles.includes('Role.Admin'), was always [] due to Fusion not returning this anymore. The roles was successfully returned when running this locally, as Fusion is not involved locally. 

What has been done:
- Use the Bearer-Token which is cached under "CACHE_ENTRY" inside localstorage. Decoded this token, and parsed the roles out of it, so where businesslogic is comparing if the user is administrator or not, uses this as their Source-Of-Truth.

Github Bug: https://github.com/equinor/fusion-bmt/issues/998